### PR TITLE
[Feature] 외박 서비스 구현 (#8)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,12 @@ bin/
 
 AGENTS.md
 .claude
+
+### Local dev scripts & logs ###
+*.log
+*.ps1
+run-*.bat
+start-*.bat
+build-*.bat
+gen_passport.py
+test_endpoints.py

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ bin/
 
 ### Mac OS ###
 .DS_Store
+
+AGENTS.md
+.claude

--- a/core/core-grpc/src/main/proto/user/user.proto
+++ b/core/core-grpc/src/main/proto/user/user.proto
@@ -19,3 +19,52 @@ message VerifyPasswordRequest {
 message VerifyPasswordResponse {
   bool valid = 1;
 }
+
+service UserQueryService {
+
+  rpc GetStudentsByUserIds (GetStudentsByUserIdsRequest)
+      returns (GetStudentsByUserIdsResponse);
+
+  rpc GetResidualStudents (GetResidualStudentsRequest)
+      returns (GetResidualStudentsResponse);
+}
+
+message GetStudentsByUserIdsRequest {
+  repeated string user_ids = 1;
+}
+
+message StudentDto {
+  int64 student_id = 1;
+  string user_id = 2;
+  string name = 3;
+  int32 grade = 4;
+  int32 room = 5;
+  int32 number = 6;
+}
+
+message GetStudentsByUserIdsResponse {
+  repeated StudentDto students = 1;
+}
+
+message GetResidualStudentsRequest {
+  repeated string absent_user_ids = 1;
+}
+
+message ResidualStudentDto {
+  string public_id = 1;
+  string name = 2;
+  string username = 3;
+  string role = 4;
+  string profile_image = 5;
+  string phone = 6;
+  int64 student_id = 7;
+  int32 grade = 8;
+  int32 room = 9;
+  int32 number = 10;
+  string created_at = 11;
+  string modified_at = 12;
+}
+
+message GetResidualStudentsResponse {
+  repeated ResidualStudentDto students = 1;
+}

--- a/core/core-grpc/src/main/proto/user/user_credential.proto
+++ b/core/core-grpc/src/main/proto/user/user_credential.proto
@@ -1,0 +1,21 @@
+syntax = "proto3";
+
+package user;
+
+option java_multiple_files = true;
+option java_package = "com.b1nd.dodamdodam.grpc.user";
+
+service UserCredentialService {
+
+  rpc VerifyPassword (VerifyPasswordRequest)
+      returns (VerifyPasswordResponse);
+}
+
+message VerifyPasswordRequest {
+  string username = 1;
+  string raw_password = 2;
+}
+
+message VerifyPasswordResponse {
+  bool valid = 1;
+}

--- a/core/core-grpc/src/main/proto/user/user_query.proto
+++ b/core/core-grpc/src/main/proto/user/user_query.proto
@@ -18,7 +18,7 @@ message GetStudentsByUserIdsRequest {
   repeated string user_ids = 1;
 }
 
-message StudentDto {
+message Student {
   int64 student_id = 1;
   string user_id = 2;
   string name = 3;
@@ -28,14 +28,14 @@ message StudentDto {
 }
 
 message GetStudentsByUserIdsResponse {
-  repeated StudentDto students = 1;
+  repeated Student students = 1;
 }
 
 message GetResidualStudentsRequest {
   repeated string absent_user_ids = 1;
 }
 
-message ResidualStudentDto {
+message ResidualStudent {
   string public_id = 1;
   string name = 2;
   string username = 3;
@@ -51,5 +51,5 @@ message ResidualStudentDto {
 }
 
 message GetResidualStudentsResponse {
-  repeated ResidualStudentDto students = 1;
+  repeated ResidualStudent students = 1;
 }

--- a/core/core-grpc/src/main/proto/user/user_query.proto
+++ b/core/core-grpc/src/main/proto/user/user_query.proto
@@ -5,21 +5,6 @@ package user;
 option java_multiple_files = true;
 option java_package = "com.b1nd.dodamdodam.grpc.user";
 
-service UserCredentialService {
-
-  rpc VerifyPassword (VerifyPasswordRequest)
-      returns (VerifyPasswordResponse);
-}
-
-message VerifyPasswordRequest {
-  string username = 1;
-  string raw_password = 2;
-}
-
-message VerifyPasswordResponse {
-  bool valid = 1;
-}
-
 service UserQueryService {
 
   rpc GetStudentsByUserIds (GetStudentsByUserIdsRequest)

--- a/core/core-jpa/build.gradle.kts
+++ b/core/core-jpa/build.gradle.kts
@@ -1,9 +1,14 @@
 plugins {
     id("buildsrc.convention.spring-boot-library")
+    kotlin("kapt")
 }
 
 dependencies {
     api(libs.springBootStarterData.jpa)
+
+    // QueryDSL Q-class generation for superclass
+    api("com.querydsl:querydsl-jpa:${libs.versions.querydsl.get()}:jakarta")
+    kapt("com.querydsl:querydsl-apt:${libs.versions.querydsl.get()}:jakarta")
 }
 
 allOpen {

--- a/core/core-security/src/main/kotlin/com/b1nd/dodamdodam/core/security/passport/PassportExtensions.kt
+++ b/core/core-security/src/main/kotlin/com/b1nd/dodamdodam/core/security/passport/PassportExtensions.kt
@@ -1,0 +1,7 @@
+package com.b1nd.dodamdodam.core.security.passport
+
+import com.b1nd.dodamdodam.core.security.exception.PassportInvalidException
+import java.util.UUID
+
+fun Passport.requireUserId(): UUID = userId ?: throw PassportInvalidException()
+fun Passport.requireUsername(): String = username ?: throw PassportInvalidException()

--- a/core/core-security/src/main/kotlin/com/b1nd/dodamdodam/core/security/passport/holder/PassportHolder.kt
+++ b/core/core-security/src/main/kotlin/com/b1nd/dodamdodam/core/security/passport/holder/PassportHolder.kt
@@ -1,0 +1,10 @@
+package com.b1nd.dodamdodam.core.security.passport.holder
+
+import com.b1nd.dodamdodam.core.security.passport.Passport
+import com.b1nd.dodamdodam.core.security.passport.PassportUserDetails
+import org.springframework.security.core.context.SecurityContextHolder
+
+object PassportHolder {
+    fun current(): Passport =
+        (SecurityContextHolder.getContext().authentication.principal as PassportUserDetails).passport
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ kafka = "3.9.0"
 r2dbcMysql = "1.0.2"
 grpc = "3.1.0.RELEASE"
 nimbusJoseJwt = "10.0.2"
+querydsl = "5.1.0"
 
 [libraries]
 kotlinGradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
@@ -45,6 +46,10 @@ springGrpc = { module = "net.devh:grpc-spring-boot-starter", version.ref= "grpc"
 
 # jwt
 jwt-nimbusJose = { module = "com.nimbusds:nimbus-jose-jwt", version.ref = "nimbusJoseJwt"}
+
+# QueryDSL
+querydsl-jpa = { module = "com.querydsl:querydsl-jpa", version.ref = "querydsl" }
+querydsl-apt = { module = "com.querydsl:querydsl-apt", version.ref = "querydsl" }
 
 # Libraries can be bundled together for easier import
 [bundles]

--- a/services/service-outsleeping/build.gradle.kts
+++ b/services/service-outsleeping/build.gradle.kts
@@ -1,0 +1,25 @@
+plugins {
+    id("buildsrc.convention.spring-boot-application")
+}
+
+dependencies {
+    implementation(project(":core:core-common"))
+    implementation(project(":core:core-security"))
+    implementation(project(":core:core-jpa"))
+
+    // database
+    runtimeOnly(libs.mysql.jdbcDriver)
+    implementation(libs.springBootStarterData.jdbc)
+    implementation(libs.springBootStarterData.jpa)
+
+    // flyway
+    implementation(libs.flywayCore)
+    implementation(libs.flywayMysql)
+
+    // grpc client
+    implementation(project(":core:core-grpc"))
+    implementation(libs.springGrpc)
+
+    // security
+    implementation(libs.springBootStarterSecurity)
+}

--- a/services/service-outsleeping/build.gradle.kts
+++ b/services/service-outsleeping/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("buildsrc.convention.spring-boot-application")
+    kotlin("kapt")
 }
 
 dependencies {
@@ -22,4 +23,8 @@ dependencies {
 
     // security
     implementation(libs.springBootStarterSecurity)
+
+    // QueryDSL
+    implementation("com.querydsl:querydsl-jpa:${libs.versions.querydsl.get()}:jakarta")
+    kapt("com.querydsl:querydsl-apt:${libs.versions.querydsl.get()}:jakarta")
 }

--- a/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/OutSleepingServiceApplication.kt
+++ b/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/OutSleepingServiceApplication.kt
@@ -1,9 +1,15 @@
 package com.b1nd.dodamdodam.outsleeping
 
+import com.b1nd.dodamdodam.core.security.annotation.EnableDodamSecurity
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 
-@SpringBootApplication
+@SpringBootApplication(scanBasePackages = ["com.b1nd.dodamdodam"])
+@EnableDodamSecurity
+@EnableWebSecurity
+@EnableJpaAuditing
 class OutSleepingServiceApplication
 
 fun main(args: Array<String>) {

--- a/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/OutSleepingServiceApplication.kt
+++ b/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/OutSleepingServiceApplication.kt
@@ -1,0 +1,11 @@
+package com.b1nd.dodamdodam.outsleeping
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+
+@SpringBootApplication
+class OutSleepingServiceApplication
+
+fun main(args: Array<String>) {
+    runApplication<OutSleepingServiceApplication>(*args)
+}

--- a/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/application/outsleeping/OutSleepingUseCase.kt
+++ b/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/application/outsleeping/OutSleepingUseCase.kt
@@ -1,0 +1,90 @@
+package com.b1nd.dodamdodam.outsleeping.application.outsleeping
+
+import com.b1nd.dodamdodam.core.security.passport.PassportUserDetails
+import com.b1nd.dodamdodam.outsleeping.application.outsleeping.data.request.OutSleepingRequest
+import com.b1nd.dodamdodam.outsleeping.application.outsleeping.data.request.RejectRequest
+import com.b1nd.dodamdodam.outsleeping.application.outsleeping.data.response.OutSleepingResponse
+import com.b1nd.dodamdodam.outsleeping.application.outsleeping.data.response.ResidualStudentResponse
+import com.b1nd.dodamdodam.outsleeping.application.outsleeping.data.response.StudentInfo
+import com.b1nd.dodamdodam.outsleeping.domain.outsleeping.entity.OutSleepingEntity
+import com.b1nd.dodamdodam.outsleeping.domain.outsleeping.service.OutSleepingService
+import com.b1nd.dodamdodam.outsleeping.infrastructure.user.client.UserGrpcClient
+import jakarta.transaction.Transactional
+import kotlinx.coroutines.runBlocking
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.stereotype.Component
+import java.time.LocalDate
+import java.util.UUID
+
+@Component
+@Transactional(rollbackOn = [Exception::class])
+class OutSleepingUseCase(
+    private val outSleepingService: OutSleepingService,
+    private val userGrpcClient: UserGrpcClient
+) {
+    private fun currentUserId(): UUID {
+        val principal = SecurityContextHolder.getContext().authentication?.principal
+        return (principal as PassportUserDetails).passport.userId!!
+    }
+
+    fun apply(request: OutSleepingRequest) {
+        val studentId = currentUserId()
+        runBlocking { userGrpcClient.getStudentByUserId(studentId) }
+
+        val entity = OutSleepingEntity(
+            studentId = studentId,
+            reason = request.reason,
+            startAt = request.startAt,
+            endAt = request.endAt
+        )
+        outSleepingService.create(entity)
+    }
+
+    fun allow(id: Long) = outSleepingService.allow(id)
+
+    fun reject(id: Long, request: RejectRequest) =
+        outSleepingService.reject(id, request.rejectReason)
+
+    fun revert(id: Long) = outSleepingService.revert(id)
+
+    fun delete(id: Long) = outSleepingService.delete(id, currentUserId())
+
+    fun findByDate(date: LocalDate): List<OutSleepingResponse> {
+        val entities = outSleepingService.findByDate(date)
+        return enrichWithStudentInfo(entities)
+    }
+
+    fun findMy(): List<OutSleepingResponse> {
+        val entities = outSleepingService.findByStudentId(currentUserId())
+        return enrichWithStudentInfo(entities)
+    }
+
+    fun findValid(): List<OutSleepingResponse> {
+        val entities = outSleepingService.findValid(LocalDate.now())
+        return enrichWithStudentInfo(entities)
+    }
+
+    fun findResidualStudents(): List<ResidualStudentResponse> {
+        val absentUserIds = outSleepingService.findValid(LocalDate.now()).map { it.studentId }
+        val residualDtos = runBlocking { userGrpcClient.getResidualStudents(absentUserIds) }
+        return residualDtos.map { ResidualStudentResponse.from(it) }
+    }
+
+    private fun enrichWithStudentInfo(entities: List<OutSleepingEntity>): List<OutSleepingResponse> {
+        if (entities.isEmpty()) return emptyList()
+        val userIds = entities.map { it.studentId }.distinct()
+        val studentDtos = runBlocking { userGrpcClient.getStudentsByUserIds(userIds) }
+        val studentByUserId = studentDtos.associateBy { UUID.fromString(it.userId) }
+
+        return entities.mapNotNull { entity ->
+            val dto = studentByUserId[entity.studentId] ?: return@mapNotNull null
+            OutSleepingResponse.of(entity, StudentInfo(
+                id = dto.studentId,
+                name = dto.name,
+                grade = dto.grade,
+                room = dto.room,
+                number = dto.number
+            ))
+        }
+    }
+}

--- a/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/application/outsleeping/OutSleepingUseCase.kt
+++ b/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/application/outsleeping/OutSleepingUseCase.kt
@@ -59,11 +59,6 @@ class OutSleepingUseCase(
         return enrichWithStudentInfo(entities)
     }
 
-    fun findValid(): List<OutSleepingResponse> {
-        val entities = outSleepingService.findValid(LocalDate.now())
-        return enrichWithStudentInfo(entities)
-    }
-
     fun findResidualStudents(): List<ResidualStudentResponse> {
         val absentUserIds = outSleepingService.findValid(LocalDate.now()).map { it.studentId }
         val residualDtos = runBlocking { userGrpcClient.getResidualStudents(absentUserIds) }

--- a/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/application/outsleeping/OutSleepingUseCase.kt
+++ b/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/application/outsleeping/OutSleepingUseCase.kt
@@ -1,6 +1,7 @@
 package com.b1nd.dodamdodam.outsleeping.application.outsleeping
 
-import com.b1nd.dodamdodam.core.security.passport.PassportUserDetails
+import com.b1nd.dodamdodam.core.security.passport.holder.PassportHolder
+import com.b1nd.dodamdodam.core.security.passport.requireUserId
 import com.b1nd.dodamdodam.outsleeping.application.outsleeping.data.request.OutSleepingRequest
 import com.b1nd.dodamdodam.outsleeping.application.outsleeping.data.request.RejectRequest
 import com.b1nd.dodamdodam.outsleeping.application.outsleeping.data.response.OutSleepingListResponse
@@ -13,7 +14,6 @@ import com.b1nd.dodamdodam.outsleeping.domain.outsleeping.service.OutSleepingSer
 import com.b1nd.dodamdodam.outsleeping.infrastructure.user.client.UserGrpcClient
 import org.springframework.transaction.annotation.Transactional
 import kotlinx.coroutines.runBlocking
-import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Component
 import java.time.LocalDate
 import java.util.UUID
@@ -24,13 +24,9 @@ class OutSleepingUseCase(
     private val outSleepingService: OutSleepingService,
     private val userGrpcClient: UserGrpcClient
 ) {
-    private fun currentUserId(): UUID {
-        val principal = SecurityContextHolder.getContext().authentication?.principal
-        return (principal as PassportUserDetails).passport.userId!!
-    }
 
     fun apply(request: OutSleepingRequest) {
-        val studentId = currentUserId()
+        val studentId = PassportHolder.current().requireUserId()
         runBlocking { userGrpcClient.getStudentByUserId(studentId) }
 
         val entity = OutSleepingEntity(
@@ -49,7 +45,7 @@ class OutSleepingUseCase(
 
     fun revert(id: Long) = outSleepingService.revert(id)
 
-    fun delete(id: Long) = outSleepingService.delete(id, currentUserId())
+    fun delete(id: Long) = outSleepingService.delete(id, PassportHolder.current().requireUserId())
 
     @Transactional(readOnly = true)
     fun findByDate(date: LocalDate): OutSleepingListResponse {
@@ -59,7 +55,7 @@ class OutSleepingUseCase(
 
     @Transactional(readOnly = true)
     fun findMy(): OutSleepingListResponse {
-        val entities = outSleepingService.findByStudentId(currentUserId())
+        val entities = outSleepingService.findByStudentId(PassportHolder.current().requireUserId())
         return OutSleepingListResponse(enrichWithStudentInfo(entities))
     }
 

--- a/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/application/outsleeping/data/request/OutSleepingRequest.kt
+++ b/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/application/outsleeping/data/request/OutSleepingRequest.kt
@@ -1,9 +1,11 @@
 package com.b1nd.dodamdodam.outsleeping.application.outsleeping.data.request
 
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
 import java.time.LocalDate
 
 data class OutSleepingRequest(
-    val reason: String,
-    val startAt: LocalDate,
-    val endAt: LocalDate
+    @field:NotBlank val reason: String,
+    @field:NotNull val startAt: LocalDate,
+    @field:NotNull val endAt: LocalDate
 )

--- a/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/application/outsleeping/data/request/OutSleepingRequest.kt
+++ b/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/application/outsleeping/data/request/OutSleepingRequest.kt
@@ -1,0 +1,9 @@
+package com.b1nd.dodamdodam.outsleeping.application.outsleeping.data.request
+
+import java.time.LocalDate
+
+data class OutSleepingRequest(
+    val reason: String,
+    val startAt: LocalDate,
+    val endAt: LocalDate
+)

--- a/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/application/outsleeping/data/request/RejectRequest.kt
+++ b/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/application/outsleeping/data/request/RejectRequest.kt
@@ -1,0 +1,5 @@
+package com.b1nd.dodamdodam.outsleeping.application.outsleeping.data.request
+
+data class RejectRequest(
+    val rejectReason: String?
+)

--- a/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/application/outsleeping/data/request/RejectRequest.kt
+++ b/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/application/outsleeping/data/request/RejectRequest.kt
@@ -1,5 +1,7 @@
 package com.b1nd.dodamdodam.outsleeping.application.outsleeping.data.request
 
+import org.springframework.lang.Nullable
+
 data class RejectRequest(
-    val rejectReason: String?
+    @field:Nullable val rejectReason: String?
 )

--- a/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/application/outsleeping/data/response/OutSleepingListResponse.kt
+++ b/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/application/outsleeping/data/response/OutSleepingListResponse.kt
@@ -1,0 +1,5 @@
+package com.b1nd.dodamdodam.outsleeping.application.outsleeping.data.response
+
+data class OutSleepingListResponse(
+    val outSleepings: List<OutSleepingResponse>
+)

--- a/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/application/outsleeping/data/response/OutSleepingResponse.kt
+++ b/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/application/outsleeping/data/response/OutSleepingResponse.kt
@@ -1,0 +1,41 @@
+package com.b1nd.dodamdodam.outsleeping.application.outsleeping.data.response
+
+import com.b1nd.dodamdodam.outsleeping.domain.outsleeping.entity.OutSleepingEntity
+import com.b1nd.dodamdodam.outsleeping.domain.outsleeping.enumeration.OutSleepingStatus
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+data class StudentInfo(
+    val id: Long,
+    val name: String,
+    val grade: Int,
+    val room: Int,
+    val number: Int
+)
+
+data class OutSleepingResponse(
+    val id: Long,
+    val reason: String,
+    val status: OutSleepingStatus,
+    val student: StudentInfo,
+    val rejectReason: String?,
+    val startAt: LocalDate,
+    val endAt: LocalDate,
+    val createdAt: LocalDateTime?,
+    val modifiedAt: LocalDateTime?
+) {
+    companion object {
+        fun of(entity: OutSleepingEntity, student: StudentInfo): OutSleepingResponse =
+            OutSleepingResponse(
+                id = entity.id!!,
+                reason = entity.reason,
+                status = entity.status,
+                student = student,
+                rejectReason = entity.rejectReason,
+                startAt = entity.startAt,
+                endAt = entity.endAt,
+                createdAt = entity.createdAt,
+                modifiedAt = entity.modifiedAt
+            )
+    }
+}

--- a/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/application/outsleeping/data/response/OutSleepingResponse.kt
+++ b/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/application/outsleeping/data/response/OutSleepingResponse.kt
@@ -1,9 +1,8 @@
 package com.b1nd.dodamdodam.outsleeping.application.outsleeping.data.response
 
 import com.b1nd.dodamdodam.outsleeping.domain.outsleeping.entity.OutSleepingEntity
-import com.b1nd.dodamdodam.outsleeping.domain.outsleeping.enumeration.OutSleepingStatus
+import com.b1nd.dodamdodam.outsleeping.domain.outsleeping.enumeration.OutSleepingStatusType
 import java.time.LocalDate
-import java.time.LocalDateTime
 
 data class StudentInfo(
     val id: Long,
@@ -14,28 +13,22 @@ data class StudentInfo(
 )
 
 data class OutSleepingResponse(
-    val id: Long,
     val reason: String,
-    val status: OutSleepingStatus,
+    val status: OutSleepingStatusType,
     val student: StudentInfo,
     val rejectReason: String?,
     val startAt: LocalDate,
-    val endAt: LocalDate,
-    val createdAt: LocalDateTime?,
-    val modifiedAt: LocalDateTime?
+    val endAt: LocalDate
 ) {
     companion object {
-        fun of(entity: OutSleepingEntity, student: StudentInfo): OutSleepingResponse =
+        fun fromEntity(entity: OutSleepingEntity, student: StudentInfo): OutSleepingResponse =
             OutSleepingResponse(
-                id = entity.id!!,
                 reason = entity.reason,
                 status = entity.status,
                 student = student,
                 rejectReason = entity.rejectReason,
                 startAt = entity.startAt,
-                endAt = entity.endAt,
-                createdAt = entity.createdAt,
-                modifiedAt = entity.modifiedAt
+                endAt = entity.endAt
             )
     }
 }

--- a/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/application/outsleeping/data/response/ResidualStudentListResponse.kt
+++ b/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/application/outsleeping/data/response/ResidualStudentListResponse.kt
@@ -1,0 +1,5 @@
+package com.b1nd.dodamdodam.outsleeping.application.outsleeping.data.response
+
+data class ResidualStudentListResponse(
+    val students: List<ResidualStudentResponse>
+)

--- a/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/application/outsleeping/data/response/ResidualStudentResponse.kt
+++ b/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/application/outsleeping/data/response/ResidualStudentResponse.kt
@@ -1,9 +1,10 @@
 package com.b1nd.dodamdodam.outsleeping.application.outsleeping.data.response
 
-import com.b1nd.dodamdodam.grpc.user.ResidualStudentDto
+import com.b1nd.dodamdodam.grpc.user.ResidualStudent
+import java.util.UUID
 
 data class ResidualStudentResponse(
-    val id: String,
+    val id: UUID,
     val name: String,
     val email: String,
     val role: String,
@@ -14,9 +15,9 @@ data class ResidualStudentResponse(
     val modifiedAt: String
 ) {
     companion object {
-        fun from(dto: ResidualStudentDto): ResidualStudentResponse =
+        fun from(dto: ResidualStudent): ResidualStudentResponse =
             ResidualStudentResponse(
-                id = dto.publicId,
+                id = UUID.fromString(dto.publicId),
                 name = dto.name,
                 email = dto.username,
                 role = dto.role,

--- a/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/application/outsleeping/data/response/ResidualStudentResponse.kt
+++ b/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/application/outsleeping/data/response/ResidualStudentResponse.kt
@@ -1,0 +1,44 @@
+package com.b1nd.dodamdodam.outsleeping.application.outsleeping.data.response
+
+import com.b1nd.dodamdodam.grpc.user.ResidualStudentDto
+
+data class ResidualStudentResponse(
+    val id: String,
+    val name: String,
+    val email: String,
+    val role: String,
+    val profileImage: String?,
+    val phone: String?,
+    val student: ResidualStudentInfo,
+    val createdAt: String,
+    val modifiedAt: String
+) {
+    companion object {
+        fun from(dto: ResidualStudentDto): ResidualStudentResponse =
+            ResidualStudentResponse(
+                id = dto.publicId,
+                name = dto.name,
+                email = dto.username,
+                role = dto.role,
+                profileImage = dto.profileImage.takeIf { it.isNotBlank() },
+                phone = dto.phone.takeIf { it.isNotBlank() },
+                student = ResidualStudentInfo(
+                    id = dto.studentId,
+                    name = dto.name,
+                    grade = dto.grade,
+                    room = dto.room,
+                    number = dto.number
+                ),
+                createdAt = dto.createdAt,
+                modifiedAt = dto.modifiedAt
+            )
+    }
+}
+
+data class ResidualStudentInfo(
+    val id: Long,
+    val name: String,
+    val grade: Int,
+    val room: Int,
+    val number: Int
+)

--- a/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/domain/outsleeping/entity/OutSleepingEntity.kt
+++ b/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/domain/outsleeping/entity/OutSleepingEntity.kt
@@ -1,0 +1,42 @@
+package com.b1nd.dodamdodam.outsleeping.domain.outsleeping.entity
+
+import com.b1nd.dodamdodam.core.jpa.entity.BaseTimeEntity
+import com.b1nd.dodamdodam.outsleeping.domain.outsleeping.enumeration.OutSleepingStatus
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.LocalDate
+import java.util.UUID
+
+@Entity
+@Table(name = "out_sleepings")
+class OutSleepingEntity(
+
+    @Column(nullable = false, columnDefinition = "BINARY(16)")
+    val studentId: UUID,
+
+    @Column(nullable = false)
+    val reason: String,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    var status: OutSleepingStatus = OutSleepingStatus.PENDING,
+
+    var rejectReason: String? = null,
+
+    @Column(nullable = false)
+    val startAt: LocalDate,
+
+    @Column(nullable = false)
+    val endAt: LocalDate
+
+) : BaseTimeEntity() {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null
+}

--- a/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/domain/outsleeping/entity/OutSleepingEntity.kt
+++ b/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/domain/outsleeping/entity/OutSleepingEntity.kt
@@ -1,7 +1,7 @@
 package com.b1nd.dodamdodam.outsleeping.domain.outsleeping.entity
 
 import com.b1nd.dodamdodam.core.jpa.entity.BaseTimeEntity
-import com.b1nd.dodamdodam.outsleeping.domain.outsleeping.enumeration.OutSleepingStatus
+import com.b1nd.dodamdodam.outsleeping.domain.outsleeping.enumeration.OutSleepingStatusType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
@@ -17,7 +17,7 @@ import java.util.UUID
 @Table(name = "out_sleepings")
 class OutSleepingEntity(
 
-    @Column(nullable = false, columnDefinition = "BINARY(16)")
+    @Column(name = "fk_student_id", nullable = false)
     val studentId: UUID,
 
     @Column(nullable = false)
@@ -25,7 +25,7 @@ class OutSleepingEntity(
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    var status: OutSleepingStatus = OutSleepingStatus.PENDING,
+    var status: OutSleepingStatusType = OutSleepingStatusType.PENDING,
 
     var rejectReason: String? = null,
 

--- a/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/domain/outsleeping/enumeration/OutSleepingStatus.kt
+++ b/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/domain/outsleeping/enumeration/OutSleepingStatus.kt
@@ -1,0 +1,7 @@
+package com.b1nd.dodamdodam.outsleeping.domain.outsleeping.enumeration
+
+enum class OutSleepingStatus {
+    PENDING,
+    ALLOWED,
+    REJECTED
+}

--- a/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/domain/outsleeping/enumeration/OutSleepingStatusType.kt
+++ b/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/domain/outsleeping/enumeration/OutSleepingStatusType.kt
@@ -1,6 +1,6 @@
 package com.b1nd.dodamdodam.outsleeping.domain.outsleeping.enumeration
 
-enum class OutSleepingStatus {
+enum class OutSleepingStatusType {
     PENDING,
     ALLOWED,
     REJECTED

--- a/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/domain/outsleeping/exception/OutSleepingException.kt
+++ b/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/domain/outsleeping/exception/OutSleepingException.kt
@@ -1,0 +1,9 @@
+package com.b1nd.dodamdodam.outsleeping.domain.outsleeping.exception
+
+import com.b1nd.dodamdodam.core.common.exception.BasicException
+
+class OutSleepingNotFoundException : BasicException(OutSleepingExceptionCode.OUT_SLEEPING_NOT_FOUND)
+class OutSleepingForbiddenException : BasicException(OutSleepingExceptionCode.OUT_SLEEPING_FORBIDDEN)
+class OutSleepingAlreadyExistsException : BasicException(OutSleepingExceptionCode.OUT_SLEEPING_ALREADY_EXISTS)
+class OutSleepingNotPendingException : BasicException(OutSleepingExceptionCode.OUT_SLEEPING_NOT_PENDING)
+class OutSleepingStudentNotFoundException : BasicException(OutSleepingExceptionCode.OUT_SLEEPING_STUDENT_NOT_FOUND)

--- a/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/domain/outsleeping/exception/OutSleepingExceptionCode.kt
+++ b/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/domain/outsleeping/exception/OutSleepingExceptionCode.kt
@@ -1,0 +1,15 @@
+package com.b1nd.dodamdodam.outsleeping.domain.outsleeping.exception
+
+import com.b1nd.dodamdodam.core.common.exception.ExceptionCode
+import org.springframework.http.HttpStatus
+
+enum class OutSleepingExceptionCode(
+    override val status: HttpStatus,
+    override val message: String
+) : ExceptionCode {
+    OUT_SLEEPING_NOT_FOUND(HttpStatus.NOT_FOUND, "외박 신청을 찾을 수 없어요."),
+    OUT_SLEEPING_FORBIDDEN(HttpStatus.FORBIDDEN, "외박 신청에 대한 권한이 없어요."),
+    OUT_SLEEPING_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 해당 날짜에 외박 신청이 존재해요."),
+    OUT_SLEEPING_NOT_PENDING(HttpStatus.BAD_REQUEST, "대기 중인 외박 신청만 삭제할 수 있어요."),
+    OUT_SLEEPING_STUDENT_NOT_FOUND(HttpStatus.NOT_FOUND, "학생 정보를 찾을 수 없어요."),
+}

--- a/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/domain/outsleeping/repository/OutSleepingRepository.kt
+++ b/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/domain/outsleeping/repository/OutSleepingRepository.kt
@@ -1,0 +1,43 @@
+package com.b1nd.dodamdodam.outsleeping.domain.outsleeping.repository
+
+import com.b1nd.dodamdodam.outsleeping.domain.outsleeping.entity.OutSleepingEntity
+import com.b1nd.dodamdodam.outsleeping.domain.outsleeping.enumeration.OutSleepingStatus
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.time.LocalDate
+import java.util.UUID
+
+interface OutSleepingRepository : JpaRepository<OutSleepingEntity, Long> {
+
+    // 날짜별 조회: startAt <= date <= endAt 인 외박 전체
+    fun findByStartAtLessThanEqualAndEndAtGreaterThanEqual(
+        endDate: LocalDate,
+        startDate: LocalDate
+    ): List<OutSleepingEntity>
+
+    // 내 외박 조회
+    fun findByStudentId(studentId: UUID): List<OutSleepingEntity>
+
+    // 유효한 외박 조회: ALLOWED + 오늘이 startAt~endAt 범위 안
+    fun findByStatusAndStartAtLessThanEqualAndEndAtGreaterThanEqual(
+        status: OutSleepingStatus,
+        endDate: LocalDate,
+        startDate: LocalDate
+    ): List<OutSleepingEntity>
+
+    // 중복 신청 여부 확인: PENDING/ALLOWED 상태에서 날짜가 겹치는 경우
+    @Query("""
+        SELECT COUNT(o) > 0
+        FROM OutSleepingEntity o
+        WHERE o.studentId = :studentId
+          AND o.status IN ('PENDING', 'ALLOWED')
+          AND o.startAt <= :endAt
+          AND o.endAt >= :startAt
+    """)
+    fun existsOverlapping(
+        @Param("studentId") studentId: UUID,
+        @Param("startAt") startAt: LocalDate,
+        @Param("endAt") endAt: LocalDate
+    ): Boolean
+}

--- a/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/domain/outsleeping/repository/OutSleepingRepository.kt
+++ b/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/domain/outsleeping/repository/OutSleepingRepository.kt
@@ -1,14 +1,12 @@
 package com.b1nd.dodamdodam.outsleeping.domain.outsleeping.repository
 
 import com.b1nd.dodamdodam.outsleeping.domain.outsleeping.entity.OutSleepingEntity
-import com.b1nd.dodamdodam.outsleeping.domain.outsleeping.enumeration.OutSleepingStatus
+import com.b1nd.dodamdodam.outsleeping.domain.outsleeping.enumeration.OutSleepingStatusType
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Query
-import org.springframework.data.repository.query.Param
 import java.time.LocalDate
 import java.util.UUID
 
-interface OutSleepingRepository : JpaRepository<OutSleepingEntity, Long> {
+interface OutSleepingRepository : JpaRepository<OutSleepingEntity, Long>, OutSleepingRepositoryCustom {
 
     // 날짜별 조회: startAt <= date <= endAt 인 외박 전체
     fun findByStartAtLessThanEqualAndEndAtGreaterThanEqual(
@@ -21,23 +19,8 @@ interface OutSleepingRepository : JpaRepository<OutSleepingEntity, Long> {
 
     // 유효한 외박 조회: ALLOWED + 오늘이 startAt~endAt 범위 안
     fun findByStatusAndStartAtLessThanEqualAndEndAtGreaterThanEqual(
-        status: OutSleepingStatus,
+        status: OutSleepingStatusType,
         endDate: LocalDate,
         startDate: LocalDate
     ): List<OutSleepingEntity>
-
-    // 중복 신청 여부 확인: PENDING/ALLOWED 상태에서 날짜가 겹치는 경우
-    @Query("""
-        SELECT COUNT(o) > 0
-        FROM OutSleepingEntity o
-        WHERE o.studentId = :studentId
-          AND o.status IN ('PENDING', 'ALLOWED')
-          AND o.startAt <= :endAt
-          AND o.endAt >= :startAt
-    """)
-    fun existsOverlapping(
-        @Param("studentId") studentId: UUID,
-        @Param("startAt") startAt: LocalDate,
-        @Param("endAt") endAt: LocalDate
-    ): Boolean
 }

--- a/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/domain/outsleeping/repository/OutSleepingRepositoryCustom.kt
+++ b/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/domain/outsleeping/repository/OutSleepingRepositoryCustom.kt
@@ -1,0 +1,8 @@
+package com.b1nd.dodamdodam.outsleeping.domain.outsleeping.repository
+
+import java.time.LocalDate
+import java.util.UUID
+
+interface OutSleepingRepositoryCustom {
+    fun existsOverlapping(studentId: UUID, startAt: LocalDate, endAt: LocalDate): Boolean
+}

--- a/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/domain/outsleeping/repository/OutSleepingRepositoryImpl.kt
+++ b/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/domain/outsleeping/repository/OutSleepingRepositoryImpl.kt
@@ -1,0 +1,26 @@
+package com.b1nd.dodamdodam.outsleeping.domain.outsleeping.repository
+
+import com.b1nd.dodamdodam.outsleeping.domain.outsleeping.entity.QOutSleepingEntity
+import com.b1nd.dodamdodam.outsleeping.domain.outsleeping.enumeration.OutSleepingStatusType
+import com.querydsl.jpa.impl.JPAQueryFactory
+import java.time.LocalDate
+import java.util.UUID
+
+class OutSleepingRepositoryImpl(
+    private val queryFactory: JPAQueryFactory
+) : OutSleepingRepositoryCustom {
+
+    override fun existsOverlapping(studentId: UUID, startAt: LocalDate, endAt: LocalDate): Boolean {
+        val qEntity = QOutSleepingEntity.outSleepingEntity
+        return queryFactory
+            .selectOne()
+            .from(qEntity)
+            .where(
+                qEntity.studentId.eq(studentId),
+                qEntity.status.`in`(OutSleepingStatusType.PENDING, OutSleepingStatusType.ALLOWED),
+                qEntity.startAt.loe(endAt),
+                qEntity.endAt.goe(startAt)
+            )
+            .fetchFirst() != null
+    }
+}

--- a/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/domain/outsleeping/service/OutSleepingService.kt
+++ b/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/domain/outsleeping/service/OutSleepingService.kt
@@ -1,7 +1,7 @@
 package com.b1nd.dodamdodam.outsleeping.domain.outsleeping.service
 
 import com.b1nd.dodamdodam.outsleeping.domain.outsleeping.entity.OutSleepingEntity
-import com.b1nd.dodamdodam.outsleeping.domain.outsleeping.enumeration.OutSleepingStatus
+import com.b1nd.dodamdodam.outsleeping.domain.outsleeping.enumeration.OutSleepingStatusType
 import com.b1nd.dodamdodam.outsleeping.domain.outsleeping.exception.OutSleepingAlreadyExistsException
 import com.b1nd.dodamdodam.outsleeping.domain.outsleeping.exception.OutSleepingForbiddenException
 import com.b1nd.dodamdodam.outsleeping.domain.outsleeping.exception.OutSleepingNotFoundException
@@ -27,25 +27,25 @@ class OutSleepingService(
 
     fun allow(id: Long) {
         val entity = findById(id)
-        entity.status = OutSleepingStatus.ALLOWED
+        entity.status = OutSleepingStatusType.ALLOWED
     }
 
     fun reject(id: Long, rejectReason: String?) {
         val entity = findById(id)
-        entity.status = OutSleepingStatus.REJECTED
+        entity.status = OutSleepingStatusType.REJECTED
         entity.rejectReason = rejectReason
     }
 
     fun revert(id: Long) {
         val entity = findById(id)
-        entity.status = OutSleepingStatus.PENDING
+        entity.status = OutSleepingStatusType.PENDING
         entity.rejectReason = null
     }
 
     fun delete(id: Long, studentId: UUID) {
         val entity = findById(id)
         if (entity.studentId != studentId) throw OutSleepingForbiddenException()
-        if (entity.status != OutSleepingStatus.PENDING) throw OutSleepingNotPendingException()
+        if (entity.status != OutSleepingStatusType.PENDING) throw OutSleepingNotPendingException()
         repository.delete(entity)
     }
 
@@ -57,6 +57,6 @@ class OutSleepingService(
 
     fun findValid(today: LocalDate): List<OutSleepingEntity> =
         repository.findByStatusAndStartAtLessThanEqualAndEndAtGreaterThanEqual(
-            OutSleepingStatus.ALLOWED, today, today
+            OutSleepingStatusType.ALLOWED, today, today
         )
 }

--- a/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/domain/outsleeping/service/OutSleepingService.kt
+++ b/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/domain/outsleeping/service/OutSleepingService.kt
@@ -1,0 +1,62 @@
+package com.b1nd.dodamdodam.outsleeping.domain.outsleeping.service
+
+import com.b1nd.dodamdodam.outsleeping.domain.outsleeping.entity.OutSleepingEntity
+import com.b1nd.dodamdodam.outsleeping.domain.outsleeping.enumeration.OutSleepingStatus
+import com.b1nd.dodamdodam.outsleeping.domain.outsleeping.exception.OutSleepingAlreadyExistsException
+import com.b1nd.dodamdodam.outsleeping.domain.outsleeping.exception.OutSleepingForbiddenException
+import com.b1nd.dodamdodam.outsleeping.domain.outsleeping.exception.OutSleepingNotFoundException
+import com.b1nd.dodamdodam.outsleeping.domain.outsleeping.exception.OutSleepingNotPendingException
+import com.b1nd.dodamdodam.outsleeping.domain.outsleeping.repository.OutSleepingRepository
+import org.springframework.stereotype.Service
+import java.time.LocalDate
+import java.util.UUID
+
+@Service
+class OutSleepingService(
+    private val repository: OutSleepingRepository
+) {
+    fun create(entity: OutSleepingEntity): OutSleepingEntity {
+        if (repository.existsOverlapping(entity.studentId, entity.startAt, entity.endAt)) {
+            throw OutSleepingAlreadyExistsException()
+        }
+        return repository.save(entity)
+    }
+
+    fun findById(id: Long): OutSleepingEntity =
+        repository.findById(id).orElseThrow { OutSleepingNotFoundException() }
+
+    fun allow(id: Long) {
+        val entity = findById(id)
+        entity.status = OutSleepingStatus.ALLOWED
+    }
+
+    fun reject(id: Long, rejectReason: String?) {
+        val entity = findById(id)
+        entity.status = OutSleepingStatus.REJECTED
+        entity.rejectReason = rejectReason
+    }
+
+    fun revert(id: Long) {
+        val entity = findById(id)
+        entity.status = OutSleepingStatus.PENDING
+        entity.rejectReason = null
+    }
+
+    fun delete(id: Long, studentId: UUID) {
+        val entity = findById(id)
+        if (entity.studentId != studentId) throw OutSleepingForbiddenException()
+        if (entity.status != OutSleepingStatus.PENDING) throw OutSleepingNotPendingException()
+        repository.delete(entity)
+    }
+
+    fun findByDate(date: LocalDate): List<OutSleepingEntity> =
+        repository.findByStartAtLessThanEqualAndEndAtGreaterThanEqual(date, date)
+
+    fun findByStudentId(studentId: UUID): List<OutSleepingEntity> =
+        repository.findByStudentId(studentId)
+
+    fun findValid(today: LocalDate): List<OutSleepingEntity> =
+        repository.findByStatusAndStartAtLessThanEqualAndEndAtGreaterThanEqual(
+            OutSleepingStatus.ALLOWED, today, today
+        )
+}

--- a/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/infrastructure/config/QueryDslConfig.kt
+++ b/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/infrastructure/config/QueryDslConfig.kt
@@ -1,0 +1,16 @@
+package com.b1nd.dodamdodam.outsleeping.infrastructure.config
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class QueryDslConfig(
+    @PersistenceContext
+    private val entityManager: EntityManager
+) {
+    @Bean
+    fun jpaQueryFactory(): JPAQueryFactory = JPAQueryFactory(entityManager)
+}

--- a/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/infrastructure/exception/OutSleepingExceptionHandler.kt
+++ b/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/infrastructure/exception/OutSleepingExceptionHandler.kt
@@ -1,0 +1,17 @@
+package com.b1nd.dodamdodam.outsleeping.infrastructure.exception
+
+import com.b1nd.dodamdodam.core.common.data.Response
+import com.b1nd.dodamdodam.core.common.exception.BasicException
+import com.b1nd.dodamdodam.core.common.exception.handler.GlobalExceptionHandler
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice
+class OutSleepingExceptionHandler : GlobalExceptionHandler {
+
+    @ExceptionHandler(BasicException::class)
+    override fun handleDodamException(exception: BasicException): ResponseEntity<Response<Unit>> {
+        return Response.error(exception).toResponseEntity()
+    }
+}

--- a/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/infrastructure/security/SecurityConfig.kt
+++ b/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/infrastructure/security/SecurityConfig.kt
@@ -1,0 +1,24 @@
+package com.b1nd.dodamdodam.outsleeping.infrastructure.security
+
+import com.b1nd.dodamdodam.core.security.filter.PassportFilter
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
+
+@Configuration
+class SecurityConfig(
+    private val passportFilter: PassportFilter
+) {
+    @Bean
+    fun filterChain(http: HttpSecurity): SecurityFilterChain {
+        http
+            .csrf { it.disable() }
+            .addFilterBefore(passportFilter, UsernamePasswordAuthenticationFilter::class.java)
+            .authorizeHttpRequests { auth ->
+                auth.anyRequest().permitAll()
+            }
+        return http.build()
+    }
+}

--- a/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/infrastructure/user/client/UserGrpcClient.kt
+++ b/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/infrastructure/user/client/UserGrpcClient.kt
@@ -2,8 +2,8 @@ package com.b1nd.dodamdodam.outsleeping.infrastructure.user.client
 
 import com.b1nd.dodamdodam.grpc.user.GetResidualStudentsRequest
 import com.b1nd.dodamdodam.grpc.user.GetStudentsByUserIdsRequest
-import com.b1nd.dodamdodam.grpc.user.ResidualStudentDto
-import com.b1nd.dodamdodam.grpc.user.StudentDto
+import com.b1nd.dodamdodam.grpc.user.ResidualStudent
+import com.b1nd.dodamdodam.grpc.user.Student
 import com.b1nd.dodamdodam.grpc.user.UserQueryServiceGrpcKt
 import com.b1nd.dodamdodam.outsleeping.domain.outsleeping.exception.OutSleepingStudentNotFoundException
 import net.devh.boot.grpc.client.inject.GrpcClient
@@ -16,7 +16,7 @@ class UserGrpcClient {
     @GrpcClient("service-user")
     private lateinit var stub: UserQueryServiceGrpcKt.UserQueryServiceCoroutineStub
 
-    suspend fun getStudentsByUserIds(userIds: List<UUID>): List<StudentDto> {
+    suspend fun getStudentsByUserIds(userIds: List<UUID>): List<Student> {
         if (userIds.isEmpty()) return emptyList()
         val request = GetStudentsByUserIdsRequest.newBuilder()
             .addAllUserIds(userIds.map { it.toString() })
@@ -24,12 +24,12 @@ class UserGrpcClient {
         return stub.getStudentsByUserIds(request).studentsList
     }
 
-    suspend fun getStudentByUserId(userId: UUID): StudentDto {
+    suspend fun getStudentByUserId(userId: UUID): Student {
         val students = getStudentsByUserIds(listOf(userId))
         return students.firstOrNull() ?: throw OutSleepingStudentNotFoundException()
     }
 
-    suspend fun getResidualStudents(absentUserIds: List<UUID>): List<ResidualStudentDto> {
+    suspend fun getResidualStudents(absentUserIds: List<UUID>): List<ResidualStudent> {
         val request = GetResidualStudentsRequest.newBuilder()
             .addAllAbsentUserIds(absentUserIds.map { it.toString() })
             .build()

--- a/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/infrastructure/user/client/UserGrpcClient.kt
+++ b/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/infrastructure/user/client/UserGrpcClient.kt
@@ -1,0 +1,38 @@
+package com.b1nd.dodamdodam.outsleeping.infrastructure.user.client
+
+import com.b1nd.dodamdodam.grpc.user.GetResidualStudentsRequest
+import com.b1nd.dodamdodam.grpc.user.GetStudentsByUserIdsRequest
+import com.b1nd.dodamdodam.grpc.user.ResidualStudentDto
+import com.b1nd.dodamdodam.grpc.user.StudentDto
+import com.b1nd.dodamdodam.grpc.user.UserQueryServiceGrpcKt
+import com.b1nd.dodamdodam.outsleeping.domain.outsleeping.exception.OutSleepingStudentNotFoundException
+import net.devh.boot.grpc.client.inject.GrpcClient
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+@Component
+class UserGrpcClient {
+
+    @GrpcClient("service-user")
+    private lateinit var stub: UserQueryServiceGrpcKt.UserQueryServiceCoroutineStub
+
+    suspend fun getStudentsByUserIds(userIds: List<UUID>): List<StudentDto> {
+        if (userIds.isEmpty()) return emptyList()
+        val request = GetStudentsByUserIdsRequest.newBuilder()
+            .addAllUserIds(userIds.map { it.toString() })
+            .build()
+        return stub.getStudentsByUserIds(request).studentsList
+    }
+
+    suspend fun getStudentByUserId(userId: UUID): StudentDto {
+        val students = getStudentsByUserIds(listOf(userId))
+        return students.firstOrNull() ?: throw OutSleepingStudentNotFoundException()
+    }
+
+    suspend fun getResidualStudents(absentUserIds: List<UUID>): List<ResidualStudentDto> {
+        val request = GetResidualStudentsRequest.newBuilder()
+            .addAllAbsentUserIds(absentUserIds.map { it.toString() })
+            .build()
+        return stub.getResidualStudents(request).studentsList
+    }
+}

--- a/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/presentation/outsleeping/OutSleepingController.kt
+++ b/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/presentation/outsleeping/OutSleepingController.kt
@@ -81,13 +81,6 @@ class OutSleepingController(
         return Response.ok("내 외박 조회 성공", data).toResponseEntity()
     }
 
-    @GetMapping("/valid")
-    @UserAccess
-    fun findValid(): ResponseEntity<Response<List<OutSleepingResponse>>> {
-        val data = useCase.findValid()
-        return Response.ok("유효한 외박 조회 성공", data).toResponseEntity()
-    }
-
     @GetMapping("/residual")
     @UserAccess(roles = [RoleType.TEACHER])
     fun findResidualStudents(): ResponseEntity<Response<List<ResidualStudentResponse>>> {

--- a/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/presentation/outsleeping/OutSleepingController.kt
+++ b/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/presentation/outsleeping/OutSleepingController.kt
@@ -1,0 +1,97 @@
+package com.b1nd.dodamdodam.outsleeping.presentation.outsleeping
+
+import com.b1nd.dodamdodam.core.common.data.Response
+import com.b1nd.dodamdodam.core.security.annotation.authentication.UserAccess
+import com.b1nd.dodamdodam.core.security.passport.enumerations.RoleType
+import com.b1nd.dodamdodam.outsleeping.application.outsleeping.OutSleepingUseCase
+import com.b1nd.dodamdodam.outsleeping.application.outsleeping.data.request.OutSleepingRequest
+import com.b1nd.dodamdodam.outsleeping.application.outsleeping.data.request.RejectRequest
+import com.b1nd.dodamdodam.outsleeping.application.outsleeping.data.response.OutSleepingResponse
+import com.b1nd.dodamdodam.outsleeping.application.outsleeping.data.response.ResidualStudentResponse
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDate
+
+@RestController
+@RequestMapping("/out-sleeping")
+class OutSleepingController(
+    private val useCase: OutSleepingUseCase
+) {
+    @PostMapping
+    @UserAccess(roles = [RoleType.STUDENT])
+    fun apply(
+        @RequestBody request: OutSleepingRequest
+    ): ResponseEntity<Response<Unit>> {
+        useCase.apply(request)
+        return Response.created<Unit>("외박 신청이 완료되었어요.").toResponseEntity()
+    }
+
+    @PatchMapping("/{id}/allow")
+    @UserAccess(roles = [RoleType.TEACHER])
+    fun allow(@PathVariable id: Long): ResponseEntity<Response<Unit>> {
+        useCase.allow(id)
+        return Response.noContent<Unit>("외박이 승인되었어요.").toResponseEntity()
+    }
+
+    @PatchMapping("/{id}/reject")
+    @UserAccess(roles = [RoleType.TEACHER])
+    fun reject(
+        @PathVariable id: Long,
+        @RequestBody request: RejectRequest
+    ): ResponseEntity<Response<Unit>> {
+        useCase.reject(id, request)
+        return Response.noContent<Unit>("외박이 거절되었어요.").toResponseEntity()
+    }
+
+    @PatchMapping("/{id}/revert")
+    @UserAccess(roles = [RoleType.TEACHER])
+    fun revert(@PathVariable id: Long): ResponseEntity<Response<Unit>> {
+        useCase.revert(id)
+        return Response.noContent<Unit>("외박이 대기 상태로 변경되었어요.").toResponseEntity()
+    }
+
+    @DeleteMapping("/{id}")
+    @UserAccess(roles = [RoleType.STUDENT])
+    fun delete(@PathVariable id: Long): ResponseEntity<Response<Unit>> {
+        useCase.delete(id)
+        return Response.noContent<Unit>("외박 신청이 취소되었어요.").toResponseEntity()
+    }
+
+    @GetMapping
+    @UserAccess(roles = [RoleType.TEACHER])
+    fun findByDate(
+        @RequestParam date: LocalDate
+    ): ResponseEntity<Response<List<OutSleepingResponse>>> {
+        val data = useCase.findByDate(date)
+        return Response.ok("날짜별 외박 조회 성공", data).toResponseEntity()
+    }
+
+    @GetMapping("/my")
+    @UserAccess(roles = [RoleType.STUDENT])
+    fun findMy(): ResponseEntity<Response<List<OutSleepingResponse>>> {
+        val data = useCase.findMy()
+        return Response.ok("내 외박 조회 성공", data).toResponseEntity()
+    }
+
+    @GetMapping("/valid")
+    @UserAccess
+    fun findValid(): ResponseEntity<Response<List<OutSleepingResponse>>> {
+        val data = useCase.findValid()
+        return Response.ok("유효한 외박 조회 성공", data).toResponseEntity()
+    }
+
+    @GetMapping("/residual")
+    @UserAccess(roles = [RoleType.TEACHER])
+    fun findResidualStudents(): ResponseEntity<Response<List<ResidualStudentResponse>>> {
+        val data = useCase.findResidualStudents()
+        return Response.ok("잔류 학생 조회 성공", data).toResponseEntity()
+    }
+}

--- a/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/presentation/outsleeping/OutSleepingController.kt
+++ b/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/presentation/outsleeping/OutSleepingController.kt
@@ -55,7 +55,7 @@ class OutSleepingController(
     @UserAccess(roles = [RoleType.TEACHER])
     fun revert(@PathVariable id: Long): ResponseEntity<Response<Unit>> {
         useCase.revert(id)
-        return Response.noContent<Unit>("외박이 대기 상태로 변경되었어요.").toResponseEntity()
+        return Response.noContent<Unit>("외박 승인이 취소되었어요.").toResponseEntity()
     }
 
     @DeleteMapping("/{id}")

--- a/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/presentation/outsleeping/OutSleepingController.kt
+++ b/services/service-outsleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/presentation/outsleeping/OutSleepingController.kt
@@ -6,8 +6,8 @@ import com.b1nd.dodamdodam.core.security.passport.enumerations.RoleType
 import com.b1nd.dodamdodam.outsleeping.application.outsleeping.OutSleepingUseCase
 import com.b1nd.dodamdodam.outsleeping.application.outsleeping.data.request.OutSleepingRequest
 import com.b1nd.dodamdodam.outsleeping.application.outsleeping.data.request.RejectRequest
-import com.b1nd.dodamdodam.outsleeping.application.outsleeping.data.response.OutSleepingResponse
-import com.b1nd.dodamdodam.outsleeping.application.outsleeping.data.response.ResidualStudentResponse
+import com.b1nd.dodamdodam.outsleeping.application.outsleeping.data.response.OutSleepingListResponse
+import com.b1nd.dodamdodam.outsleeping.application.outsleeping.data.response.ResidualStudentListResponse
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
+import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
@@ -28,7 +29,7 @@ class OutSleepingController(
     @PostMapping
     @UserAccess(roles = [RoleType.STUDENT])
     fun apply(
-        @RequestBody request: OutSleepingRequest
+        @RequestBody @Valid request: OutSleepingRequest
     ): ResponseEntity<Response<Unit>> {
         useCase.apply(request)
         return Response.created<Unit>("외박 신청이 완료되었어요.").toResponseEntity()
@@ -69,21 +70,21 @@ class OutSleepingController(
     @UserAccess(roles = [RoleType.TEACHER])
     fun findByDate(
         @RequestParam date: LocalDate
-    ): ResponseEntity<Response<List<OutSleepingResponse>>> {
+    ): ResponseEntity<Response<OutSleepingListResponse>> {
         val data = useCase.findByDate(date)
         return Response.ok("날짜별 외박 조회 성공", data).toResponseEntity()
     }
 
     @GetMapping("/my")
     @UserAccess(roles = [RoleType.STUDENT])
-    fun findMy(): ResponseEntity<Response<List<OutSleepingResponse>>> {
+    fun findMy(): ResponseEntity<Response<OutSleepingListResponse>> {
         val data = useCase.findMy()
         return Response.ok("내 외박 조회 성공", data).toResponseEntity()
     }
 
     @GetMapping("/residual")
     @UserAccess(roles = [RoleType.TEACHER])
-    fun findResidualStudents(): ResponseEntity<Response<List<ResidualStudentResponse>>> {
+    fun findResidualStudents(): ResponseEntity<Response<ResidualStudentListResponse>> {
         val data = useCase.findResidualStudents()
         return Response.ok("잔류 학생 조회 성공", data).toResponseEntity()
     }

--- a/services/service-outsleeping/src/main/resources/application-local.yml
+++ b/services/service-outsleeping/src/main/resources/application-local.yml
@@ -20,6 +20,8 @@ spring:
     password: ${MYSQL_PASSWORD}
 
 grpc:
+  server:
+    port: -1
   client:
     service-user:
       address: 'static://localhost:9090'

--- a/services/service-outsleeping/src/main/resources/application-local.yml
+++ b/services/service-outsleeping/src/main/resources/application-local.yml
@@ -1,0 +1,29 @@
+spring:
+  datasource:
+    url: jdbc:${MYSQL_HOST}
+    username: ${MYSQL_USER}
+    password: ${MYSQL_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: none
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.MySQLDialect
+
+  flyway:
+    url: jdbc:${MYSQL_HOST}
+    user: ${MYSQL_USER}
+    password: ${MYSQL_PASSWORD}
+
+grpc:
+  client:
+    service-user:
+      address: 'static://localhost:9090'
+      negotiation-type: plaintext
+
+server:
+  port: 8083

--- a/services/service-outsleeping/src/main/resources/application.yml
+++ b/services/service-outsleeping/src/main/resources/application.yml
@@ -1,0 +1,18 @@
+spring:
+  application:
+    name: service-outsleeping
+
+  profiles:
+    active: local
+
+  main:
+    web-application-type: servlet
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info
+
+server:
+  port: 8083

--- a/services/service-outsleeping/src/main/resources/db/migration/V1__create_out_sleepings.sql
+++ b/services/service-outsleeping/src/main/resources/db/migration/V1__create_out_sleepings.sql
@@ -1,0 +1,12 @@
+CREATE TABLE out_sleepings
+(
+    id            BIGINT       NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    student_id    BINARY(16)   NOT NULL,
+    reason        VARCHAR(255) NOT NULL,
+    status        VARCHAR(20)  NOT NULL DEFAULT 'PENDING',
+    reject_reason VARCHAR(255) NULL,
+    start_at      DATE         NOT NULL,
+    end_at        DATE         NOT NULL,
+    created_at    DATETIME     NOT NULL,
+    modified_at   DATETIME     NOT NULL
+);

--- a/services/service-outsleeping/src/main/resources/db/migration/V2__rename_student_id_to_fk_student_id.sql
+++ b/services/service-outsleeping/src/main/resources/db/migration/V2__rename_student_id_to_fk_student_id.sql
@@ -1,0 +1,2 @@
+ALTER TABLE out_sleepings
+    RENAME COLUMN student_id TO fk_student_id;

--- a/services/service-user/src/main/kotlin/com/b1nd/dodamdodam/user/application/query/UserQueryUseCase.kt
+++ b/services/service-user/src/main/kotlin/com/b1nd/dodamdodam/user/application/query/UserQueryUseCase.kt
@@ -1,0 +1,30 @@
+package com.b1nd.dodamdodam.user.application.query
+
+import com.b1nd.dodamdodam.user.domain.student.entity.StudentEntity
+import com.b1nd.dodamdodam.user.domain.student.repository.StudentRepository
+import com.b1nd.dodamdodam.user.domain.user.entity.UserRoleEntity
+import com.b1nd.dodamdodam.user.domain.user.repository.UserRoleRepository
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Component
+@Transactional(readOnly = true)
+class UserQueryUseCase(
+    private val studentRepository: StudentRepository,
+    private val userRoleRepository: UserRoleRepository
+) {
+    fun getStudentsByUserIds(userIds: List<UUID>): List<StudentEntity> =
+        studentRepository.findByUserPublicIdIn(userIds)
+
+    fun getResidualStudents(absentUserIds: List<UUID>): List<Pair<StudentEntity, UserRoleEntity?>> {
+        val residualStudents = if (absentUserIds.isEmpty()) {
+            studentRepository.findAllByOrderByUserIdAsc()
+        } else {
+            studentRepository.findByUserPublicIdNotIn(absentUserIds)
+        }
+        return residualStudents.map { student ->
+            student to userRoleRepository.findFirstByUser(student.user)
+        }
+    }
+}

--- a/services/service-user/src/main/kotlin/com/b1nd/dodamdodam/user/application/query/UserQueryUseCase.kt
+++ b/services/service-user/src/main/kotlin/com/b1nd/dodamdodam/user/application/query/UserQueryUseCase.kt
@@ -15,7 +15,7 @@ class UserQueryUseCase(
     private val userRoleRepository: UserRoleRepository
 ) {
     fun getStudentsByUserIds(userIds: List<UUID>): List<StudentEntity> =
-        studentRepository.findByUserPublicIdIn(userIds)
+        studentRepository.findByUserPublicIdInFetchUser(userIds)
 
     fun getResidualStudents(absentUserIds: List<UUID>): List<Pair<StudentEntity, UserRoleEntity?>> {
         val residualStudents = if (absentUserIds.isEmpty()) {

--- a/services/service-user/src/main/kotlin/com/b1nd/dodamdodam/user/domain/student/repository/StudentRepository.kt
+++ b/services/service-user/src/main/kotlin/com/b1nd/dodamdodam/user/domain/student/repository/StudentRepository.kt
@@ -2,10 +2,14 @@ package com.b1nd.dodamdodam.user.domain.student.repository
 
 import com.b1nd.dodamdodam.user.domain.student.entity.StudentEntity
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import java.util.UUID
 
 interface StudentRepository: JpaRepository<StudentEntity, Long> {
     fun findByUserPublicIdIn(userIds: List<UUID>): List<StudentEntity>
     fun findByUserPublicIdNotIn(userIds: List<UUID>): List<StudentEntity>
     fun findAllByOrderByUserIdAsc(): List<StudentEntity>
+
+    @Query("SELECT s FROM StudentEntity s JOIN FETCH s.user WHERE s.user.publicId IN :userIds")
+    fun findByUserPublicIdInFetchUser(userIds: List<UUID>): List<StudentEntity>
 }

--- a/services/service-user/src/main/kotlin/com/b1nd/dodamdodam/user/domain/student/repository/StudentRepository.kt
+++ b/services/service-user/src/main/kotlin/com/b1nd/dodamdodam/user/domain/student/repository/StudentRepository.kt
@@ -2,6 +2,10 @@ package com.b1nd.dodamdodam.user.domain.student.repository
 
 import com.b1nd.dodamdodam.user.domain.student.entity.StudentEntity
 import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
 
 interface StudentRepository: JpaRepository<StudentEntity, Long> {
+    fun findByUserPublicIdIn(userIds: List<UUID>): List<StudentEntity>
+    fun findByUserPublicIdNotIn(userIds: List<UUID>): List<StudentEntity>
+    fun findAllByOrderByUserIdAsc(): List<StudentEntity>
 }

--- a/services/service-user/src/main/kotlin/com/b1nd/dodamdodam/user/domain/user/repository/UserRoleRepository.kt
+++ b/services/service-user/src/main/kotlin/com/b1nd/dodamdodam/user/domain/user/repository/UserRoleRepository.kt
@@ -1,7 +1,9 @@
 package com.b1nd.dodamdodam.user.domain.user.repository
 
+import com.b1nd.dodamdodam.user.domain.user.entity.UserEntity
 import com.b1nd.dodamdodam.user.domain.user.entity.UserRoleEntity
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface UserRoleRepository: JpaRepository<UserRoleEntity, Long> {
+    fun findFirstByUser(user: UserEntity): UserRoleEntity?
 }

--- a/services/service-user/src/main/kotlin/com/b1nd/dodamdodam/user/presentation/user/grpc/UserQueryGrpcController.kt
+++ b/services/service-user/src/main/kotlin/com/b1nd/dodamdodam/user/presentation/user/grpc/UserQueryGrpcController.kt
@@ -22,20 +22,18 @@ class UserQueryGrpcController(
     private val dtFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSS")
 
     override suspend fun getStudentsByUserIds(request: GetStudentsByUserIdsRequest): GetStudentsByUserIdsResponse {
-        val students = blockingExecutor.execute {
+        val dtos = blockingExecutor.execute {
             val userIds = request.userIdsList.map { UUID.fromString(it) }
-            useCase.getStudentsByUserIds(userIds)
-        }
-
-        val dtos = students.map { student ->
-            StudentDto.newBuilder()
-                .setStudentId(student.id!!)
-                .setUserId(student.user.publicId.toString())
-                .setName(student.user.name)
-                .setGrade(student.grade)
-                .setRoom(student.room)
-                .setNumber(student.number)
-                .build()
+            useCase.getStudentsByUserIds(userIds).map { student ->
+                StudentDto.newBuilder()
+                    .setStudentId(student.id!!)
+                    .setUserId(student.user.publicId.toString())
+                    .setName(student.user.name)
+                    .setGrade(student.grade)
+                    .setRoom(student.room)
+                    .setNumber(student.number)
+                    .build()
+            }
         }
 
         return GetStudentsByUserIdsResponse.newBuilder()
@@ -44,27 +42,25 @@ class UserQueryGrpcController(
     }
 
     override suspend fun getResidualStudents(request: GetResidualStudentsRequest): GetResidualStudentsResponse {
-        val pairs = blockingExecutor.execute {
+        val dtos = blockingExecutor.execute {
             val absentUserIds = request.absentUserIdsList.map { UUID.fromString(it) }
-            useCase.getResidualStudents(absentUserIds)
-        }
-
-        val dtos = pairs.map { (student, roleEntity) ->
-            val user = student.user
-            ResidualStudentDto.newBuilder()
-                .setPublicId(user.publicId.toString())
-                .setName(user.name)
-                .setUsername(user.username)
-                .setRole(roleEntity?.role?.name ?: "STUDENT")
-                .setProfileImage(user.profileImage ?: "")
-                .setPhone(user.phone ?: "")
-                .setStudentId(student.id!!)
-                .setGrade(student.grade)
-                .setRoom(student.room)
-                .setNumber(student.number)
-                .setCreatedAt(student.user.createdAt?.format(dtFormatter) ?: "")
-                .setModifiedAt(student.user.modifiedAt?.format(dtFormatter) ?: "")
-                .build()
+            useCase.getResidualStudents(absentUserIds).map { (student, roleEntity) ->
+                val user = student.user
+                ResidualStudentDto.newBuilder()
+                    .setPublicId(user.publicId.toString())
+                    .setName(user.name)
+                    .setUsername(user.username)
+                    .setRole(roleEntity?.role?.name ?: "STUDENT")
+                    .setProfileImage(user.profileImage ?: "")
+                    .setPhone(user.phone ?: "")
+                    .setStudentId(student.id!!)
+                    .setGrade(student.grade)
+                    .setRoom(student.room)
+                    .setNumber(student.number)
+                    .setCreatedAt(student.user.createdAt?.format(dtFormatter) ?: "")
+                    .setModifiedAt(student.user.modifiedAt?.format(dtFormatter) ?: "")
+                    .build()
+            }
         }
 
         return GetResidualStudentsResponse.newBuilder()

--- a/services/service-user/src/main/kotlin/com/b1nd/dodamdodam/user/presentation/user/grpc/UserQueryGrpcController.kt
+++ b/services/service-user/src/main/kotlin/com/b1nd/dodamdodam/user/presentation/user/grpc/UserQueryGrpcController.kt
@@ -5,8 +5,8 @@ import com.b1nd.dodamdodam.grpc.user.GetResidualStudentsRequest
 import com.b1nd.dodamdodam.grpc.user.GetResidualStudentsResponse
 import com.b1nd.dodamdodam.grpc.user.GetStudentsByUserIdsRequest
 import com.b1nd.dodamdodam.grpc.user.GetStudentsByUserIdsResponse
-import com.b1nd.dodamdodam.grpc.user.ResidualStudentDto
-import com.b1nd.dodamdodam.grpc.user.StudentDto
+import com.b1nd.dodamdodam.grpc.user.ResidualStudent
+import com.b1nd.dodamdodam.grpc.user.Student
 import com.b1nd.dodamdodam.grpc.user.UserQueryServiceGrpcKt
 import com.b1nd.dodamdodam.user.application.query.UserQueryUseCase
 import net.devh.boot.grpc.server.service.GrpcService
@@ -25,7 +25,7 @@ class UserQueryGrpcController(
         val dtos = blockingExecutor.execute {
             val userIds = request.userIdsList.map { UUID.fromString(it) }
             useCase.getStudentsByUserIds(userIds).map { student ->
-                StudentDto.newBuilder()
+                Student.newBuilder()
                     .setStudentId(student.id!!)
                     .setUserId(student.user.publicId.toString())
                     .setName(student.user.name)
@@ -46,7 +46,7 @@ class UserQueryGrpcController(
             val absentUserIds = request.absentUserIdsList.map { UUID.fromString(it) }
             useCase.getResidualStudents(absentUserIds).map { (student, roleEntity) ->
                 val user = student.user
-                ResidualStudentDto.newBuilder()
+                ResidualStudent.newBuilder()
                     .setPublicId(user.publicId.toString())
                     .setName(user.name)
                     .setUsername(user.username)

--- a/services/service-user/src/main/kotlin/com/b1nd/dodamdodam/user/presentation/user/grpc/UserQueryGrpcController.kt
+++ b/services/service-user/src/main/kotlin/com/b1nd/dodamdodam/user/presentation/user/grpc/UserQueryGrpcController.kt
@@ -1,0 +1,74 @@
+package com.b1nd.dodamdodam.user.presentation.user.grpc
+
+import com.b1nd.dodamdodam.core.common.coroutine.CoroutineBlockingExecutor
+import com.b1nd.dodamdodam.grpc.user.GetResidualStudentsRequest
+import com.b1nd.dodamdodam.grpc.user.GetResidualStudentsResponse
+import com.b1nd.dodamdodam.grpc.user.GetStudentsByUserIdsRequest
+import com.b1nd.dodamdodam.grpc.user.GetStudentsByUserIdsResponse
+import com.b1nd.dodamdodam.grpc.user.ResidualStudentDto
+import com.b1nd.dodamdodam.grpc.user.StudentDto
+import com.b1nd.dodamdodam.grpc.user.UserQueryServiceGrpcKt
+import com.b1nd.dodamdodam.user.application.query.UserQueryUseCase
+import net.devh.boot.grpc.server.service.GrpcService
+import java.time.format.DateTimeFormatter
+import java.util.UUID
+
+@GrpcService
+class UserQueryGrpcController(
+    private val useCase: UserQueryUseCase,
+    private val blockingExecutor: CoroutineBlockingExecutor
+) : UserQueryServiceGrpcKt.UserQueryServiceCoroutineImplBase() {
+
+    private val dtFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSS")
+
+    override suspend fun getStudentsByUserIds(request: GetStudentsByUserIdsRequest): GetStudentsByUserIdsResponse {
+        val students = blockingExecutor.execute {
+            val userIds = request.userIdsList.map { UUID.fromString(it) }
+            useCase.getStudentsByUserIds(userIds)
+        }
+
+        val dtos = students.map { student ->
+            StudentDto.newBuilder()
+                .setStudentId(student.id!!)
+                .setUserId(student.user.publicId.toString())
+                .setName(student.user.name)
+                .setGrade(student.grade)
+                .setRoom(student.room)
+                .setNumber(student.number)
+                .build()
+        }
+
+        return GetStudentsByUserIdsResponse.newBuilder()
+            .addAllStudents(dtos)
+            .build()
+    }
+
+    override suspend fun getResidualStudents(request: GetResidualStudentsRequest): GetResidualStudentsResponse {
+        val pairs = blockingExecutor.execute {
+            val absentUserIds = request.absentUserIdsList.map { UUID.fromString(it) }
+            useCase.getResidualStudents(absentUserIds)
+        }
+
+        val dtos = pairs.map { (student, roleEntity) ->
+            val user = student.user
+            ResidualStudentDto.newBuilder()
+                .setPublicId(user.publicId.toString())
+                .setName(user.name)
+                .setUsername(user.username)
+                .setRole(roleEntity?.role?.name ?: "STUDENT")
+                .setProfileImage(user.profileImage ?: "")
+                .setPhone(user.phone ?: "")
+                .setStudentId(student.id!!)
+                .setGrade(student.grade)
+                .setRoom(student.room)
+                .setNumber(student.number)
+                .setCreatedAt(student.user.createdAt?.format(dtFormatter) ?: "")
+                .setModifiedAt(student.user.modifiedAt?.format(dtFormatter) ?: "")
+                .build()
+        }
+
+        return GetResidualStudentsResponse.newBuilder()
+            .addAllStudents(dtos)
+            .build()
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -34,5 +34,6 @@ include(":services:service-gateway")
 include(":services:service-auth")
 include(":services:service-user")
 include("services:service-inapp")
+include(":services:service-outsleeping")
 
 rootProject.name = "dodamdodam-server"


### PR DESCRIPTION
## 변경 사항
외박(OutSleeping) 마이크로서비스를 신규 구현하고, service-user에 학생 조회 gRPC API를 추가했습니다.

## 작업 내용

### service-outsleeping (신규)
- `OutSleepingEntity`: 외박 신청 엔티티 (studentId, status, reason, rejectReason, startAt, endAt)
- `OutSleepingStatus`: PENDING / ALLOWED / REJECTED
- `OutSleepingRepository`: 날짜 범위 조회, 유효한 외박 조회, 중복 신청 체크 쿼리
- `OutSleepingService`: 도메인 서비스 (저장/조회/삭제)
- `OutSleepingUseCase`: 전체 비즈니스 로직 (apply, allow, reject, revert, delete, findByDate, findMy, findValid, findResidualStudents)
- `OutSleepingController`: 9개 HTTP API
- `UserGrpcClient`: service-user gRPC 클라이언트
- `SecurityConfig`: PassportFilter 등록
- Flyway 마이그레이션: `V1__create_out_sleepings.sql`

### service-user (수정)
- `UserQueryUseCase` + `UserQueryGrpcController` 신규 추가
- `StudentRepository`: `findByUserPublicIdIn`, `findByUserPublicIdNotIn` 추가
- `UserRoleRepository`: `findFirstByUser` 추가

### core-grpc (수정)
- `user.proto`에 `UserQueryService` 추가 (GetStudentsByUserIds, GetResidualStudents)

## 테스트 방법
- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 완료
- [x] 수동 테스트 완료

## 관련 이슈
Resolves #8

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 완료했습니다
- [x] 문서를 업데이트했습니다 (필요한 경우)
- [x] Breaking Changes가 없습니다