### PR TITLE
fix: yt-dlp 명령 인젝션 방지를 위해 videoId 검증 및 URL 재구성

### DIFF
--- a/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/application/WakeupSongUseCase.kt
+++ b/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/application/WakeupSongUseCase.kt
@@ -112,7 +112,7 @@ class WakeupSongUseCase(
         val videoId = YouTubeClient.extractVideoId(url)
             ?: throw YouTubeVideoNotFoundException()
         val videoInfo = youTubeClient.getVideoInfo(videoId)
-        val file = ytDlpClient.downloadMp3(url)
+        val file = ytDlpClient.downloadMp3(videoId)
         val bytes = Files.readAllBytes(file)
         Files.deleteIfExists(file)
         val response = FileDownloadResponse(bytes, "${videoInfo.videoTitle}.mp3", MediaType.parseMediaType("audio/mpeg"))

--- a/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/domain/wakeupsong/exception/WakeupSongExceptionCode.kt
+++ b/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/domain/wakeupsong/exception/WakeupSongExceptionCode.kt
@@ -12,5 +12,6 @@ enum class WakeupSongExceptionCode(
     YOUTUBE_VIDEO_NOT_FOUND(HttpStatus.NOT_FOUND, "유튜브 영상을 찾을 수 없어요."),
     MELON_CHART_FETCH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "멜론 차트를 가져올 수 없어요."),
     AUDIO_DOWNLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "오디오 다운로드에 실패했어요."),
+    INVALID_VIDEO_ID(HttpStatus.BAD_REQUEST, "유효하지 않은 영상 ID에요."),
     ;
 }

--- a/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/domain/wakeupsong/exception/WakeupSongExceptions.kt
+++ b/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/domain/wakeupsong/exception/WakeupSongExceptions.kt
@@ -7,3 +7,4 @@ class WakeupSongNotOwnerException : BasicException(WakeupSongExceptionCode.WAKEU
 class YouTubeVideoNotFoundException : BasicException(WakeupSongExceptionCode.YOUTUBE_VIDEO_NOT_FOUND)
 class MelonChartFetchFailedException : BasicException(WakeupSongExceptionCode.MELON_CHART_FETCH_FAILED)
 class AudioDownloadFailedException : BasicException(WakeupSongExceptionCode.AUDIO_DOWNLOAD_FAILED)
+class InvalidVideoIdException : BasicException(WakeupSongExceptionCode.INVALID_VIDEO_ID)

--- a/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/infrastructure/youtube/YtDlpClient.kt
+++ b/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/infrastructure/youtube/YtDlpClient.kt
@@ -1,6 +1,7 @@
 package com.b1nd.dodamdodam.wakeupsong.infrastructure.youtube
 
 import com.b1nd.dodamdodam.wakeupsong.domain.wakeupsong.exception.AudioDownloadFailedException
+import com.b1nd.dodamdodam.wakeupsong.domain.wakeupsong.exception.InvalidVideoIdException
 import org.springframework.stereotype.Component
 import java.nio.file.Files
 import java.nio.file.Path
@@ -10,8 +11,8 @@ import java.util.concurrent.TimeUnit
 class YtDlpClient {
 
     fun downloadMp3(videoId: String): Path {
-        require(videoId.matches(Regex("^[a-zA-Z0-9_-]{11}$"))) {
-            "Invalid video ID"
+        if (!videoId.matches(Regex("^[a-zA-Z0-9_-]{11}$"))) {
+            throw InvalidVideoIdException()
         }
 
         val safeUrl = "https://www.youtube.com/watch?v=$videoId"

--- a/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/infrastructure/youtube/YtDlpClient.kt
+++ b/services/service-wakeup-song/src/main/kotlin/com/b1nd/dodamdodam/wakeupsong/infrastructure/youtube/YtDlpClient.kt
@@ -9,7 +9,12 @@ import java.util.concurrent.TimeUnit
 @Component
 class YtDlpClient {
 
-    fun downloadMp3(url: String): Path {
+    fun downloadMp3(videoId: String): Path {
+        require(videoId.matches(Regex("^[a-zA-Z0-9_-]{11}$"))) {
+            "Invalid video ID"
+        }
+
+        val safeUrl = "https://www.youtube.com/watch?v=$videoId"
         val tmpFile = Files.createTempFile("wakeup-song-", ".mp3")
         Files.delete(tmpFile)
 
@@ -21,7 +26,7 @@ class YtDlpClient {
             "--audio-format", "mp3",
             "--audio-quality", "0",
             "-o", "$outputTemplate.%(ext)s",
-            url
+            safeUrl
         )
             .redirectErrorStream(true)
             .start()


### PR DESCRIPTION
## 변경 내용

- yt-dlp 명령 인젝션 방지: 사용자 입력 URL 대신 검증된 videoId로 URL 재구성
- videoId 정규식 검증 (`^[a-zA-Z0-9_-]{11}$`) 추가


## 관련 이슈

- Resolves #36


## 테스트 방법

- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 완료
- [X] 수동 테스트 완료


## 스크린샷 (UI 변경 시)

<!-- UI 변경이 있다면 Before/After 스크린샷을 첨부해주세요 -->

### Before
<!-- 변경 전 스크린샷 -->

### After
<!-- 변경 후 스크린샷 -->


## 체크리스트

- [X] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [X] 자체 코드 리뷰를 완료했습니다
- [ ] 변경 사항에 대한 테스트를 추가했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [X] Breaking Changes가 없습니다


## 기타 사항

<!-- 리뷰어가 특별히 주의해서 봐야 할 부분이나 추가 설명 -->