### PR TITLE
[Feature] 외박 서비스 CI/CD 및 Docker Compose 구성 추가 (#8)

### DIFF
--- a/.github/workflows/cd-develop.yml
+++ b/.github/workflows/cd-develop.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Rename jars to predictable names
         run: |
-          for service in gateway auth user wakeup-song inapp file neis; do
+          for service in gateway auth user wakeup-song inapp file neis out-sleeping; do
             dir="services/service-${service}/build/libs"
             jar=$(find "$dir" -name "service-${service}-*.jar" ! -name "*-plain.jar" | head -1)
             if [ -n "$jar" ]; then
@@ -129,6 +129,16 @@ jobs:
           push: true
           tags: ${{ env.IMAGE_PREFIX }}-neis:dev
           build-args: JAR_FILE=service-neis.jar
+
+      - name: Build & Push service-out-sleeping
+        uses: docker/build-push-action@v6
+        with:
+          context: services/service-out-sleeping/build/libs
+          file: builds/develop/Dockerfile
+          platforms: linux/arm64
+          push: true
+          tags: ${{ env.IMAGE_PREFIX }}-out-sleeping:dev
+          build-args: JAR_FILE=service-out-sleeping.jar
 
       - name: Deploy to Dev Server
         uses: appleboy/ssh-action@v1

--- a/builds/develop/docker-compose.yml
+++ b/builds/develop/docker-compose.yml
@@ -171,6 +171,19 @@ services:
       mysql:
         condition: service_healthy
 
+  service-out-sleeping:
+    image: ${DOCKERHUB_USERNAME}/dodam-out-sleeping:dev
+    container_name: dodam-out-sleeping
+    restart: unless-stopped
+    environment:
+      SPRING_PROFILES_ACTIVE: dev
+      MYSQL_HOST: mysql://mysql:3306/dodam-out-sleeping
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+    depends_on:
+      mysql:
+        condition: service_healthy
+
   service-file:
     image: ${DOCKERHUB_USERNAME}/dodam-file:dev
     container_name: dodam-file

--- a/services/service-out-sleeping/src/main/resources/application-dev.yml
+++ b/services/service-out-sleeping/src/main/resources/application-dev.yml
@@ -1,0 +1,28 @@
+spring:
+  datasource:
+    url: jdbc:${MYSQL_HOST}
+    username: ${MYSQL_USER}
+    password: ${MYSQL_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  flyway:
+    url: jdbc:${MYSQL_HOST}
+    user: ${MYSQL_USER}
+    password: ${MYSQL_PASSWORD}
+
+  jpa:
+    hibernate:
+      ddl-auto: none
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.MySQLDialect
+
+grpc:
+  client:
+    service-user:
+      address: 'static://service-user:9090'
+      negotiation-type: plaintext
+
+server:
+  port: 8080


### PR DESCRIPTION
## 변경 내용
외박 서비스(out-sleeping)의 CI/CD 파이프라인 및 Docker Compose 구성을 추가했습니다.

- `application-dev.yml` 추가 (dev 프로파일: MySQL, Flyway, gRPC 컨테이너 주소 설정)
- `cd-develop.yml`에 out-sleeping 서비스 빌드/푸시 단계 추가
- `docker-compose.yml`에 out-sleeping 서비스 컨테이너 정의 추가

## 작업 내용
- `application-dev.yml`: dev 환경용 MySQL, Flyway, JPA, gRPC 클라이언트(`service-user:9090`) 설정
- `cd-develop.yml`: jar 리네임 루프에 `out-sleeping` 추가, Docker 이미지 빌드/푸시 단계 추가
- `docker-compose.yml`: MySQL 의존성을 가진 `service-out-sleeping` 컨테이너 정의

## 관련 이슈
Resolve #8

## 테스트 방법
- develop 머지 후 GitHub Actions CD 워크플로우 정상 실행 확인
- Docker 이미지 빌드/푸시 정상 동작 확인
- dev 서버에서 out-sleeping 컨테이너 정상 기동 확인

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 완료했습니다
- [x] Breaking Changes가 없습니다