### PR TITLE
Refactor/#96 remove outsleeping list response

### DIFF
--- a/services/service-out-sleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/application/outsleeping/OutSleepingUseCase.kt
+++ b/services/service-out-sleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/application/outsleeping/OutSleepingUseCase.kt
@@ -8,7 +8,7 @@ import com.b1nd.dodamdodam.outsleeping.application.outsleeping.data.request.Deny
 import com.b1nd.dodamdodam.outsleeping.application.outsleeping.data.request.ModifyOutSleepingRequest
 import com.b1nd.dodamdodam.outsleeping.application.outsleeping.data.request.UpdateDeadlineRequest
 import com.b1nd.dodamdodam.outsleeping.application.outsleeping.data.response.DeadlineResponse
-import com.b1nd.dodamdodam.outsleeping.application.outsleeping.data.response.MyOutSleepingListResponse
+import com.b1nd.dodamdodam.outsleeping.application.outsleeping.data.response.MyOutSleepingResponse
 import com.b1nd.dodamdodam.outsleeping.application.outsleeping.data.response.OutSleepingResponse
 import com.b1nd.dodamdodam.core.common.data.InfinityScrollPageResponse
 import com.b1nd.dodamdodam.outsleeping.application.outsleeping.data.toEntity
@@ -57,14 +57,12 @@ class OutSleepingUseCase(
     }
 
     @Transactional(readOnly = true)
-    fun getMy(): Response<MyOutSleepingListResponse> {
+    fun getMy(): Response<List<MyOutSleepingResponse>> {
         val userId = currentUserId()
         val outSleepings = outSleepingService.getByUserId(userId)
         return Response.ok(
             "내 외박 신청 목록을 조회했어요.",
-            MyOutSleepingListResponse(
-                outSleeping = outSleepings.map { it.toMyResponse() },
-            )
+            outSleepings.map { it.toMyResponse() },
         )
     }
 

--- a/services/service-out-sleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/application/outsleeping/data/response/MyOutSleepingResponse.kt
+++ b/services/service-out-sleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/application/outsleeping/data/response/MyOutSleepingResponse.kt
@@ -4,10 +4,6 @@ import com.b1nd.dodamdodam.outsleeping.domain.outsleeping.enumeration.OutSleepin
 import java.time.LocalDate
 import java.util.UUID
 
-data class MyOutSleepingListResponse(
-    val outSleeping: List<MyOutSleepingResponse>,
-)
-
 data class MyOutSleepingResponse(
     val publicId: UUID,
     val reason: String,


### PR DESCRIPTION
## 변경 내용

`GET /me` API에서 `MyOutSleepingListResponse` 래퍼 클래스를 제거하고, 다른 서비스와 동일하게 `Response<List<MyOutSleepingResponse>>`로 직접 반환하도록 수정했습니다.

## 관련 이슈

- Resolves #96

## 테스트 방법

- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 완료
- [x] 수동 테스트 완료


## 스크린샷 (UI 변경 시)

### Before

### After


## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 완료했습니다
- [ ] 변경 사항에 대한 테스트를 추가했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] Breaking Changes가 없습니다


## 기타 사항

응답 형식이 변경되므로 클라이언트 측에서 `outSleeping` 키 제거에 대한 대응이 필요합니다.