### PR TITLE
[Feat] 어드민 권한 부여 API 추가 (#106)

### DIFF
--- a/services/service-user/src/main/kotlin/com/b1nd/dodamdodam/user/application/user/UserUseCase.kt
+++ b/services/service-user/src/main/kotlin/com/b1nd/dodamdodam/user/application/user/UserUseCase.kt
@@ -11,6 +11,7 @@ import com.b1nd.dodamdodam.user.application.user.data.request.ChangePasswordRequ
 import com.b1nd.dodamdodam.user.application.user.data.request.ChangePhoneRequest
 import com.b1nd.dodamdodam.user.application.user.data.request.ConfirmPhoneVerificationRequest
 import com.b1nd.dodamdodam.user.application.user.data.request.EnableUserRequest
+import com.b1nd.dodamdodam.user.application.user.data.request.GrantAdminRequest
 import com.b1nd.dodamdodam.user.application.user.data.request.RequestPhoneVerificationRequest
 import com.b1nd.dodamdodam.user.application.user.data.request.ResetPasswordRequest
 import com.b1nd.dodamdodam.user.application.user.data.request.StudentRegisterRequest
@@ -111,6 +112,17 @@ class UserUseCase(
         )
 
         return Response.created("선생님 계정이 생성되었어요.")
+    }
+
+    fun grantAdmin(request: GrantAdminRequest): Response<Any> {
+        val user = userService.get(request.userId)
+        userService.addRole(user, setOf(RoleType.ADMIN))
+        val userRoles = userService.getRoles(user)
+        kafkaMessageProducer.send(
+            KafkaTopics.USER_UPDATED,
+            user.toUserUpdatedEvent(userRoles)
+        )
+        return Response.ok("어드민 권한이 부여되었어요.")
     }
 
     fun enableUser(request: EnableUserRequest): Response<Any> {

--- a/services/service-user/src/main/kotlin/com/b1nd/dodamdodam/user/application/user/data/request/GrantAdminRequest.kt
+++ b/services/service-user/src/main/kotlin/com/b1nd/dodamdodam/user/application/user/data/request/GrantAdminRequest.kt
@@ -1,0 +1,9 @@
+package com.b1nd.dodamdodam.user.application.user.data.request
+
+import jakarta.validation.constraints.NotBlank
+import java.util.UUID
+
+data class GrantAdminRequest(
+    @NotBlank
+    val userId: UUID,
+)

--- a/services/service-user/src/main/kotlin/com/b1nd/dodamdodam/user/presentation/user/http/UserController.kt
+++ b/services/service-user/src/main/kotlin/com/b1nd/dodamdodam/user/presentation/user/http/UserController.kt
@@ -87,7 +87,7 @@ class UserController(
         userUseCase.getAllUsers()
 
     @UserAccess(roles = [RoleType.ADMIN])
-    @PostMapping("/grant-admin")
+    @PatchMapping("/grant-admin")
     fun grantAdmin(@RequestBody request: GrantAdminRequest) =
         userUseCase.grantAdmin(request)
 

--- a/services/service-user/src/main/kotlin/com/b1nd/dodamdodam/user/presentation/user/http/UserController.kt
+++ b/services/service-user/src/main/kotlin/com/b1nd/dodamdodam/user/presentation/user/http/UserController.kt
@@ -6,6 +6,7 @@ import com.b1nd.dodamdodam.user.application.user.UserUseCase
 import com.b1nd.dodamdodam.user.application.user.data.request.ChangePasswordRequest
 import com.b1nd.dodamdodam.user.application.user.data.request.ConfirmPhoneVerificationRequest
 import com.b1nd.dodamdodam.user.application.user.data.request.EnableUserRequest
+import com.b1nd.dodamdodam.user.application.user.data.request.GrantAdminRequest
 import com.b1nd.dodamdodam.user.application.user.data.request.RequestPhoneVerificationRequest
 import com.b1nd.dodamdodam.user.application.user.data.request.ResetPasswordRequest
 import com.b1nd.dodamdodam.user.application.user.data.request.StudentRegisterRequest
@@ -84,6 +85,11 @@ class UserController(
     @GetMapping("/all")
     fun getAllUsers() =
         userUseCase.getAllUsers()
+
+    @UserAccess(roles = [RoleType.ADMIN])
+    @PostMapping("/grant-admin")
+    fun grantAdmin(@RequestBody request: GrantAdminRequest) =
+        userUseCase.grantAdmin(request)
 
     @UserAccess(roles = [RoleType.ADMIN])
     @PostMapping("/enable-user")


### PR DESCRIPTION
## 변경 내용

유저에게 어드민 권한을 부여하는 API를 추가했습니다.

- `POST /grant-admin` 엔드포인트 추가 (ADMIN 전용)
- `publicId`(UUID)로 대상 유저를 지정하여 ADMIN 역할 부여
- 역할 부여 후 Kafka `USER_UPDATED` 이벤트 발행하여 auth 서비스와 동기화

## 관련 이슈

- Resolves #106

## 테스트 방법

- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 완료
- [ ] 수동 테스트 완료


## 스크린샷 (UI 변경 시)

### Before

### After


## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 완료했습니다
- [ ] 변경 사항에 대한 테스트를 추가했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] Breaking Changes가 없습니다


## 기타 사항

- 이미 ADMIN 역할이 있는 유저에게 요청해도 중복 추가되지 않습니다 (`UserService.addRole()` 내부에서 기존 역할 체크)