### PR TITLE
[Feature] 유저 정지 API 추가 (#107)

### DIFF
--- a/services/service-user/src/main/kotlin/com/b1nd/dodamdodam/user/application/user/UserUseCase.kt
+++ b/services/service-user/src/main/kotlin/com/b1nd/dodamdodam/user/application/user/UserUseCase.kt
@@ -12,6 +12,7 @@ import com.b1nd.dodamdodam.user.application.user.data.request.ChangePhoneRequest
 import com.b1nd.dodamdodam.user.application.user.data.request.ConfirmPhoneVerificationRequest
 import com.b1nd.dodamdodam.user.application.user.data.request.EnableUserRequest
 import com.b1nd.dodamdodam.user.application.user.data.request.GrantAdminRequest
+import com.b1nd.dodamdodam.user.application.user.data.request.DeactivateUserRequest
 import com.b1nd.dodamdodam.user.application.user.data.request.RequestPhoneVerificationRequest
 import com.b1nd.dodamdodam.user.application.user.data.request.ResetPasswordRequest
 import com.b1nd.dodamdodam.user.application.user.data.request.StudentRegisterRequest
@@ -123,6 +124,16 @@ class UserUseCase(
             user.toUserUpdatedEvent(userRoles)
         )
         return Response.ok("어드민 권한이 부여되었어요.")
+    }
+
+    fun deactivateUser(request: DeactivateUserRequest): Response<Any> {
+        val user = userService.delete(request.userId)
+        val userRoles = userService.getRoles(user)
+        kafkaMessageProducer.send(
+            KafkaTopics.USER_UPDATED,
+            user.toUserUpdatedEvent(userRoles)
+        )
+        return Response.ok("유저가 정지되었어요.")
     }
 
     fun enableUser(request: EnableUserRequest): Response<Any> {

--- a/services/service-user/src/main/kotlin/com/b1nd/dodamdodam/user/application/user/data/request/DeactivateUserRequest.kt
+++ b/services/service-user/src/main/kotlin/com/b1nd/dodamdodam/user/application/user/data/request/DeactivateUserRequest.kt
@@ -1,0 +1,9 @@
+package com.b1nd.dodamdodam.user.application.user.data.request
+
+import jakarta.validation.constraints.NotBlank
+import java.util.UUID
+
+data class DeactivateUserRequest(
+    @NotBlank
+    val userId: UUID,
+)

--- a/services/service-user/src/main/kotlin/com/b1nd/dodamdodam/user/presentation/user/http/UserController.kt
+++ b/services/service-user/src/main/kotlin/com/b1nd/dodamdodam/user/presentation/user/http/UserController.kt
@@ -98,7 +98,7 @@ class UserController(
         userUseCase.deactivateUser(request)
 
     @UserAccess(roles = [RoleType.ADMIN])
-    @PostMapping("/enable-user")
+    @PostMapping("/enable")
     fun enableUser(@RequestBody request: EnableUserRequest) =
         userUseCase.enableUser(request)
 

--- a/services/service-user/src/main/kotlin/com/b1nd/dodamdodam/user/presentation/user/http/UserController.kt
+++ b/services/service-user/src/main/kotlin/com/b1nd/dodamdodam/user/presentation/user/http/UserController.kt
@@ -93,7 +93,7 @@ class UserController(
         userUseCase.grantAdmin(request)
 
     @UserAccess(roles = [RoleType.ADMIN])
-    @PatchMapping("/deactivate-user")
+    @PatchMapping("/deactivate")
     fun deactivateUser(@RequestBody request: DeactivateUserRequest) =
         userUseCase.deactivateUser(request)
 

--- a/services/service-user/src/main/kotlin/com/b1nd/dodamdodam/user/presentation/user/http/UserController.kt
+++ b/services/service-user/src/main/kotlin/com/b1nd/dodamdodam/user/presentation/user/http/UserController.kt
@@ -7,6 +7,7 @@ import com.b1nd.dodamdodam.user.application.user.data.request.ChangePasswordRequ
 import com.b1nd.dodamdodam.user.application.user.data.request.ConfirmPhoneVerificationRequest
 import com.b1nd.dodamdodam.user.application.user.data.request.EnableUserRequest
 import com.b1nd.dodamdodam.user.application.user.data.request.GrantAdminRequest
+import com.b1nd.dodamdodam.user.application.user.data.request.DeactivateUserRequest
 import com.b1nd.dodamdodam.user.application.user.data.request.RequestPhoneVerificationRequest
 import com.b1nd.dodamdodam.user.application.user.data.request.ResetPasswordRequest
 import com.b1nd.dodamdodam.user.application.user.data.request.StudentRegisterRequest
@@ -90,6 +91,11 @@ class UserController(
     @PatchMapping("/grant-admin")
     fun grantAdmin(@RequestBody request: GrantAdminRequest) =
         userUseCase.grantAdmin(request)
+
+    @UserAccess(roles = [RoleType.ADMIN])
+    @PatchMapping("/deactivate-user")
+    fun deactivateUser(@RequestBody request: DeactivateUserRequest) =
+        userUseCase.deactivateUser(request)
 
     @UserAccess(roles = [RoleType.ADMIN])
     @PostMapping("/enable-user")


### PR DESCRIPTION
## 변경 내용

관리자(ADMIN)가 유저를 정지(DEACTIVATED)할 수 있는 API를 추가했습니다.

- `PATCH /deactivate-user` 엔드포인트 추가 (ADMIN 전용)
- `publicId`(UUID)로 대상 유저를 지정하여 상태를 DEACTIVATED로 변경
- 정지 후 Kafka `USER_UPDATED` 이벤트 발행하여 다른 서비스와 동기화

## 관련 이슈

- Resolves #107

## 테스트 방법

- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 완료
- [ ] 수동 테스트 완료


## 스크린샷 (UI 변경 시)

### Before

### After


## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 완료했습니다
- [ ] 변경 사항에 대한 테스트를 추가했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] Breaking Changes가 없습니다


## 기타 사항

- 기존 `UserService.delete()` 메서드를 재사용하여 status를 DEACTIVATED로 변경 (소프트 삭제)