### PR TITLE
[Feat] 유저 졸업생 전환 API 추가 (#109)

### DIFF
--- a/services/service-user/src/main/kotlin/com/b1nd/dodamdodam/user/application/user/UserUseCase.kt
+++ b/services/service-user/src/main/kotlin/com/b1nd/dodamdodam/user/application/user/UserUseCase.kt
@@ -11,6 +11,7 @@ import com.b1nd.dodamdodam.user.application.user.data.request.ChangePasswordRequ
 import com.b1nd.dodamdodam.user.application.user.data.request.ChangePhoneRequest
 import com.b1nd.dodamdodam.user.application.user.data.request.ConfirmPhoneVerificationRequest
 import com.b1nd.dodamdodam.user.application.user.data.request.EnableUserRequest
+import com.b1nd.dodamdodam.user.application.user.data.request.GraduateStudentRequest
 import com.b1nd.dodamdodam.user.application.user.data.request.GrantAdminRequest
 import com.b1nd.dodamdodam.user.application.user.data.request.RequestPhoneVerificationRequest
 import com.b1nd.dodamdodam.user.application.user.data.request.ResetPasswordRequest
@@ -202,5 +203,16 @@ class UserUseCase(
         phoneVerificationStore.ensureActive(request.phone)
         userService.updatePasswordByPhone(request.phone, request.newPassword)
         return Response.ok("비밀번호 재설정에 성공했어요.")
+    }
+
+    fun graduateStudent(request: GraduateStudentRequest): Response<Any> {
+        val user = userService.get(request.userId)
+        studentService.graduate(user)
+        val userRoles = userService.getRoles(user)
+        kafkaMessageProducer.send(
+            KafkaTopics.USER_UPDATED,
+            user.toUserUpdatedEvent(userRoles)
+        )
+        return Response.ok("졸업생으로 전환되었어요.")
     }
 }

--- a/services/service-user/src/main/kotlin/com/b1nd/dodamdodam/user/application/user/data/request/GraduateStudentRequest.kt
+++ b/services/service-user/src/main/kotlin/com/b1nd/dodamdodam/user/application/user/data/request/GraduateStudentRequest.kt
@@ -1,0 +1,9 @@
+package com.b1nd.dodamdodam.user.application.user.data.request
+
+import jakarta.validation.constraints.NotBlank
+import java.util.UUID
+
+data class GraduateStudentRequest(
+    @NotBlank
+    val userId: UUID,
+)

--- a/services/service-user/src/main/kotlin/com/b1nd/dodamdodam/user/domain/student/service/StudentService.kt
+++ b/services/service-user/src/main/kotlin/com/b1nd/dodamdodam/user/domain/student/service/StudentService.kt
@@ -28,4 +28,10 @@ class StudentService(
         val student = repository.findByUser(user) ?: throw StudentNotFoundException()
         student.updateInfo(grade, room, number)
     }
+
+    fun graduate(user: UserEntity): StudentEntity {
+        val student = repository.findByUser(user) ?: throw StudentNotFoundException()
+        student.isGraduated = true
+        return repository.save(student)
+    }
 }

--- a/services/service-user/src/main/kotlin/com/b1nd/dodamdodam/user/presentation/user/http/UserController.kt
+++ b/services/service-user/src/main/kotlin/com/b1nd/dodamdodam/user/presentation/user/http/UserController.kt
@@ -105,7 +105,7 @@ class UserController(
     @PatchMapping("/reset-password")
     fun resetPassword(@RequestBody request: ResetPasswordRequest) = userUseCase.resetPassword(request)
 
-    @UserAccess(roles = [RoleType.STUDENT])
+    @UserAccess(roles = [RoleType.STUDENT, RoleType.ADMIN])
     @PatchMapping("/graduate")
     fun graduateStudent(@RequestBody request: GraduateStudentRequest) =
         userUseCase.graduateStudent(request)

--- a/services/service-user/src/main/kotlin/com/b1nd/dodamdodam/user/presentation/user/http/UserController.kt
+++ b/services/service-user/src/main/kotlin/com/b1nd/dodamdodam/user/presentation/user/http/UserController.kt
@@ -6,6 +6,7 @@ import com.b1nd.dodamdodam.user.application.user.UserUseCase
 import com.b1nd.dodamdodam.user.application.user.data.request.ChangePasswordRequest
 import com.b1nd.dodamdodam.user.application.user.data.request.ConfirmPhoneVerificationRequest
 import com.b1nd.dodamdodam.user.application.user.data.request.EnableUserRequest
+import com.b1nd.dodamdodam.user.application.user.data.request.GraduateStudentRequest
 import com.b1nd.dodamdodam.user.application.user.data.request.GrantAdminRequest
 import com.b1nd.dodamdodam.user.application.user.data.request.RequestPhoneVerificationRequest
 import com.b1nd.dodamdodam.user.application.user.data.request.ResetPasswordRequest
@@ -103,4 +104,9 @@ class UserController(
 
     @PatchMapping("/reset-password")
     fun resetPassword(@RequestBody request: ResetPasswordRequest) = userUseCase.resetPassword(request)
+
+    @UserAccess(roles = [RoleType.STUDENT])
+    @PatchMapping("/graduate")
+    fun graduateStudent(@RequestBody request: GraduateStudentRequest) =
+        userUseCase.graduateStudent(request)
 }


### PR DESCRIPTION
## 변경 내용

유저를 졸업생으로 전환하는 API를 추가했습니다.

- `PATCH /graduate` 엔드포인트 추가 (STUDENT 권한)
- `publicId`(UUID)로 대상 유저를 지정하여 졸업생으로 전환
- 졸업 전환 후 Kafka `USER_UPDATED` 이벤트 발행하여 타 서비스와 동기화

## 관련 이슈

- Resolves #109

## 테스트 방법

- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 완료
- [ ] 수동 테스트 완료

## 스크린샷 (UI 변경 시)

### Before

### After

## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 완료했습니다
- [ ] 변경 사항에 대한 테스트를 추가했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] Breaking Changes가 없습니다

## 기타 사항

- `StudentEntity.isGraduated` 필드를 `true`로 변경하며, 유저 상태(`StatusType`)는 변경하지 않습니다