### PR TITLE
fix: 심자 신청 시간 제한 미적용 문제 수정

### DIFF
--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/NightStudyUseCase.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/NightStudyUseCase.kt
@@ -177,10 +177,10 @@ class NightStudyUseCase (
     }
 
     val appliedAt: LocalDateTime
-        get() = LocalDate.now().atTime(3, 23)
+        get() = LocalDate.now().atTime(20, 30, 0)
 
     private fun isActiveNow(): Unit {
-        if (appliedAt.isAfter(LocalDateTime.now())) {
+        if (LocalDateTime.now().isAfter(appliedAt)) {
             throw BasicException(NightStudyExceptionCode.NOT_APPLICATION_TIME)
         }
     }

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/NightStudyUseCase.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/NightStudyUseCase.kt
@@ -180,7 +180,7 @@ class NightStudyUseCase (
         get() = LocalDate.now().atTime(3, 23)
 
     private fun isActiveNow(): Unit {
-        if (appliedAt.isBefore(LocalDateTime.now())) {
+        if (appliedAt.isAfter(LocalDateTime.now())) {
             throw BasicException(NightStudyExceptionCode.NOT_APPLICATION_TIME)
         }
     }

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/NightStudyUseCase.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/NightStudyUseCase.kt
@@ -43,14 +43,14 @@ class NightStudyUseCase (
 
     fun applyPersonalNightStudy(request: PersonalNightStudyApplyRequest): Response<Any> {
         val userId = PassportHolder.current().requireUserId()
-        isActiveNow()
+        validateApplicationTime()
         nightStudyService.save(request.toEntity(), userId, null)
         return Response.created("개인 심자 신청이 완료됐어요.")
     }
 
     fun applyProjectNightStudy(request: ProjectNightStudyApplyRequest): Response<Any> {
         val userId = PassportHolder.current().requireUserId()
-        isActiveNow()
+        validateApplicationTime()
         nightStudyService.save(request.toEntity(), userId, request.members)
         return Response.created("프로젝트 심자 신청이 완료됐어요.")
     }
@@ -176,11 +176,9 @@ class NightStudyUseCase (
             .associate { it.publicId to it.toOpenApiUserInfoResponse() }
     }
 
-    val appliedAt: LocalDateTime
-        get() = LocalDate.now().atTime(20, 30, 0)
-
-    private fun isActiveNow(): Unit {
-        if (LocalDateTime.now().isAfter(appliedAt)) {
+    private fun validateApplicationTime() {
+        val deadline = LocalDate.now().atTime(20,30)
+        if (LocalDateTime.now().isAfter(deadline)) {
             throw BasicException(NightStudyExceptionCode.NOT_APPLICATION_TIME)
         }
     }

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/NightStudyUseCase.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/NightStudyUseCase.kt
@@ -22,11 +22,15 @@ import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.service.NightStudyServic
 import com.b1nd.dodamdodam.nightstudy.domain.room.service.ProjectRoomService
 import com.b1nd.dodamdodam.nightstudy.infrastructure.user.client.UserQueryClient
 import com.b1nd.dodamdodam.core.common.data.InfinityScrollPageResponse
+import com.b1nd.dodamdodam.core.common.exception.BasicException
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.enumeration.NightStudyStatusType
+import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.exception.NightStudyExceptionCode
 import kotlinx.coroutines.runBlocking
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+import java.time.LocalDateTime
 import java.util.UUID
 
 @Component
@@ -39,12 +43,14 @@ class NightStudyUseCase (
 
     fun applyPersonalNightStudy(request: PersonalNightStudyApplyRequest): Response<Any> {
         val userId = PassportHolder.current().requireUserId()
+        isActiveNow()
         nightStudyService.save(request.toEntity(), userId, null)
         return Response.created("개인 심자 신청이 완료됐어요.")
     }
 
     fun applyProjectNightStudy(request: ProjectNightStudyApplyRequest): Response<Any> {
         val userId = PassportHolder.current().requireUserId()
+        isActiveNow()
         nightStudyService.save(request.toEntity(), userId, request.members)
         return Response.created("프로젝트 심자 신청이 완료됐어요.")
     }
@@ -168,6 +174,15 @@ class NightStudyUseCase (
         val userIds = (listOfNotNull(leaderId) + memberIds).map { it.toString() }
         return runBlocking { userQueryClient.getUsers(userIds) }.usersList
             .associate { it.publicId to it.toOpenApiUserInfoResponse() }
+    }
+
+    val appliedAt: LocalDateTime
+        get() = LocalDate.now().atTime(3, 23)
+
+    private fun isActiveNow(): Unit {
+        if (appliedAt.isBefore(LocalDateTime.now())) {
+            throw BasicException(NightStudyExceptionCode.NOT_APPLICATION_TIME)
+        }
     }
 }
 

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/NightStudyUseCase.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/NightStudyUseCase.kt
@@ -178,9 +178,8 @@ class NightStudyUseCase (
 
     private fun validateApplicationTime() {
         val deadline = LocalDate.now().atTime(20,30)
-        if (LocalDateTime.now().isAfter(deadline)) {
+        if (LocalDateTime.now().isAfter(deadline))
             throw BasicException(NightStudyExceptionCode.NOT_APPLICATION_TIME)
-        }
     }
 }
 

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/exception/NightStudyExceptionCode.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/exception/NightStudyExceptionCode.kt
@@ -9,13 +9,13 @@ enum class NightStudyExceptionCode(
 ): ExceptionCode {
     NIGHT_STUDY_NOT_FOUND(HttpStatus.NOT_FOUND, "심야 자습 신청을 찾을 수 없어요."),
     NIGHT_STUDY_BANNED(HttpStatus.FORBIDDEN, "심야 자습이 정지된 인원이 있어요."),
-    NOT_MY_NIGHT_STUDY(HttpStatus.FORBIDDEN, "내가 신청한 심야 자습이 아니에요."),
+    NOT_MY_NIGHT_STUDY(HttpStatus.FORBIDDEN, "내가 신청한 심야 자습이 아니예요."),
     NOT_LEADER(HttpStatus.FORBIDDEN, "프로젝트 심야 자습은 리더만 삭제할 수 있어요."),
     PERIOD_OVERLAPPED(HttpStatus.BAD_REQUEST, "이미 해당 기간에 신청한 심야 자습이 있어요."),
     BAN_NOT_FOUND(HttpStatus.NOT_FOUND, "정지된 인원을 찾을 수 없어요."),
     ALREADY_BANNED(HttpStatus.CONFLICT, "이미 정지된 인원이에요."),
     NOT_PROJECT_NIGHT_STUDY(HttpStatus.BAD_REQUEST, "프로젝트 심야 자습에만 방을 배정할 수 있어요."),
     ROOM_ALREADY_ASSIGNED(HttpStatus.CONFLICT, "해당 기간에 이미 배정된 방이에요."),
-    NOT_APPLICATION_TIME(HttpStatus.BAD_REQUEST, "지금은 심자 신청 시간이 아니에요."),
+    NOT_APPLICATION_TIME(HttpStatus.BAD_REQUEST, "지금은 심자 신청 시간이 아니예요."),
     ;
 }

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/exception/NightStudyExceptionCode.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/exception/NightStudyExceptionCode.kt
@@ -16,6 +16,6 @@ enum class NightStudyExceptionCode(
     ALREADY_BANNED(HttpStatus.CONFLICT, "이미 정지된 인원이에요."),
     NOT_PROJECT_NIGHT_STUDY(HttpStatus.BAD_REQUEST, "프로젝트 심야 자습에만 방을 배정할 수 있어요."),
     ROOM_ALREADY_ASSIGNED(HttpStatus.CONFLICT, "해당 기간에 이미 배정된 방이에요."),
-    NOT_APPLICATION_TIME(HttpStatus.BAD_REQUEST, "지금은 심자 신청 시간이 아닙니다."),
+    NOT_APPLICATION_TIME(HttpStatus.BAD_REQUEST, "지금은 심자 신청 시간이 아니에요."),
     ;
 }

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/exception/NightStudyExceptionCode.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/exception/NightStudyExceptionCode.kt
@@ -9,13 +9,13 @@ enum class NightStudyExceptionCode(
 ): ExceptionCode {
     NIGHT_STUDY_NOT_FOUND(HttpStatus.NOT_FOUND, "심야 자습 신청을 찾을 수 없어요."),
     NIGHT_STUDY_BANNED(HttpStatus.FORBIDDEN, "심야 자습이 정지된 인원이 있어요."),
-    NOT_MY_NIGHT_STUDY(HttpStatus.FORBIDDEN, "내가 신청한 심야 자습이 아니예요."),
+    NOT_MY_NIGHT_STUDY(HttpStatus.FORBIDDEN, "내가 신청한 심야 자습이 아니에요."),
     NOT_LEADER(HttpStatus.FORBIDDEN, "프로젝트 심야 자습은 리더만 삭제할 수 있어요."),
     PERIOD_OVERLAPPED(HttpStatus.BAD_REQUEST, "이미 해당 기간에 신청한 심야 자습이 있어요."),
     BAN_NOT_FOUND(HttpStatus.NOT_FOUND, "정지된 인원을 찾을 수 없어요."),
     ALREADY_BANNED(HttpStatus.CONFLICT, "이미 정지된 인원이에요."),
     NOT_PROJECT_NIGHT_STUDY(HttpStatus.BAD_REQUEST, "프로젝트 심야 자습에만 방을 배정할 수 있어요."),
     ROOM_ALREADY_ASSIGNED(HttpStatus.CONFLICT, "해당 기간에 이미 배정된 방이에요."),
-    NOT_APPLICATION_TIME(HttpStatus.BAD_REQUEST, "지금은 심자 신청 시간이 아니예요."),
+    NOT_APPLICATION_TIME(HttpStatus.BAD_REQUEST, "지금은 심자 신청 시간이 아니에요."),
     ;
 }

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/exception/NightStudyExceptionCode.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/exception/NightStudyExceptionCode.kt
@@ -16,5 +16,6 @@ enum class NightStudyExceptionCode(
     ALREADY_BANNED(HttpStatus.CONFLICT, "이미 정지된 인원이에요."),
     NOT_PROJECT_NIGHT_STUDY(HttpStatus.BAD_REQUEST, "프로젝트 심야 자습에만 방을 배정할 수 있어요."),
     ROOM_ALREADY_ASSIGNED(HttpStatus.CONFLICT, "해당 기간에 이미 배정된 방이에요."),
+    NOT_APPLICATION_TIME(HttpStatus.BAD_REQUEST, "지금은 심자 신청 시간이 아닙니다."),
     ;
 }

--- a/services/service-nightstudy/src/main/resources/application-local.yml
+++ b/services/service-nightstudy/src/main/resources/application-local.yml
@@ -19,9 +19,11 @@ spring:
         dialect: org.hibernate.dialect.MySQLDialect
 
 server:
-  port: 8087
+  port: 8088
 
 grpc:
+  server:
+    port: 9095
   client:
     service-user:
       address: 'static://localhost:9091'


### PR DESCRIPTION
## 변경 내용
이 브랜치에서는 심야자습 신청 시 20:30 시간 제한이 정상적으로 동작하지 않던 문제를 수정했습니다.

NightStudyUseCase에 당일 20:30을 기준으로 하는 appliedAt 프로퍼티와 isActiveNow() 검증 로직을 추가하여, 허용된 시간 범위를 벗어난 경우 NOT_APPLICATION_TIME 예외가 발생하도록 처리했습니다.
<!-- 이 PR에서 무엇을 변경했는지 간단히 요약해주세요 -->


## 관련 이슈

<!-- 관련된 이슈를 연결해주세요 -->
- Resolves #143 


## 테스트 방법

<!-- 어떻게 테스트했는지 설명해주세요 -->
- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 완료
- [x] 수동 테스트 완료


## 스크린샷 (UI 변경 시)

<!-- UI 변경이 있다면 Before/After 스크린샷을 첨부해주세요 -->

### Before
<!-- 변경 전 스크린샷 -->

### After
<!-- 변경 후 스크린샷 -->


## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [ ] 자체 코드 리뷰를 완료했습니다
- [ ] 변경 사항에 대한 테스트를 추가했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [ ] Breaking Changes가 없습니다


## 기타 사항

<!-- 리뷰어가 특별히 주의해서 봐야 할 부분이나 추가 설명 -->