### PR TITLE
Feature/#142 nightstudy period overlap by type

### DIFF
--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepository.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepository.kt
@@ -17,4 +17,5 @@ interface NightStudyQueryRepository {
     fun existsByPublicIdAndUserId(publicId: UUID, userId: UUID): Boolean
     fun existsByUserIdAndPeriodOverlap(userId: UUID, period: Int, type: NightStudyType, startAt: LocalDate, endAt: LocalDate): Boolean
     fun existsByRoomAndPeriodOverlap(roomId: Long, period: Int, startAt: LocalDate, endAt: LocalDate, excludeNightStudyId: Long): Boolean
+    fun findActivePersonalsByUserIdsAndPeriodOverlap(userIds: List<UUID>, period: Int, startAt: LocalDate, endAt: LocalDate): List<NightStudyEntity>
 }

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepository.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepository.kt
@@ -15,6 +15,6 @@ interface NightStudyQueryRepository {
     fun findAllByTypeAndStatus(type: NightStudyType, status: NightStudyStatusType?, pageable: Pageable): Page<NightStudyEntity>
     fun findAllByTypeAndUserIdsAndStatus(type: NightStudyType, userIds: List<UUID>, status: NightStudyStatusType?, pageable: Pageable): Page<NightStudyEntity>
     fun existsByPublicIdAndUserId(publicId: UUID, userId: UUID): Boolean
-    fun existsByUserIdAndPeriodOverlap(userId: UUID, period: Int, startAt: LocalDate, endAt: LocalDate): Boolean
+    fun existsByUserIdAndPeriodOverlap(userId: UUID, period: Int, type: NightStudyType, startAt: LocalDate, endAt: LocalDate): Boolean
     fun existsByRoomAndPeriodOverlap(roomId: Long, period: Int, startAt: LocalDate, endAt: LocalDate, excludeNightStudyId: Long): Boolean
 }

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepositoryImpl.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepositoryImpl.kt
@@ -177,6 +177,29 @@ class NightStudyQueryRepositoryImpl(
             .fetchFirst() != null
     }
 
+    override fun findActivePersonalsByUserIdsAndPeriodOverlap(
+        userIds: List<UUID>,
+        period: Int,
+        startAt: LocalDate,
+        endAt: LocalDate
+    ): List<NightStudyEntity> {
+        if (userIds.isEmpty()) return emptyList()
+
+        return queryFactory.select(nightStudyEntity)
+            .from(nightStudyMemberEntity)
+            .join(nightStudyMemberEntity.nightStudy, nightStudyEntity)
+            .where(
+                nightStudyEntity.type.eq(NightStudyType.PERSONAL),
+                nightStudyEntity.status.`in`(NightStudyStatusType.PENDING, NightStudyStatusType.ALLOWED),
+                nightStudyEntity.period.eq(period),
+                nightStudyEntity.startAt.loe(endAt),
+                nightStudyEntity.endAt.goe(startAt),
+                nightStudyMemberEntity.userId.`in`(userIds)
+            )
+            .distinct()
+            .fetch()
+    }
+
     private fun hideByActiveProjectCondition(type: NightStudyType): BooleanExpression? {
         if (type != NightStudyType.PERSONAL) return null
 

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepositoryImpl.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepositoryImpl.kt
@@ -1,11 +1,15 @@
 package com.b1nd.dodamdodam.nightstudy.domain.nightstudy.repository.nightStudy
 
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.entity.NightStudyEntity
+import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.entity.QNightStudyEntity
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.entity.QNightStudyEntity.nightStudyEntity
+import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.entity.QNightStudyMemberEntity
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.entity.QNightStudyMemberEntity.nightStudyMemberEntity
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.enumeration.NightStudyStatusType
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.enumeration.NightStudyType
 import com.b1nd.dodamdodam.nightstudy.domain.room.entity.QProjectRoomEntity
+import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.jpa.JPAExpressions
 import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
@@ -67,7 +71,8 @@ class NightStudyQueryRepositoryImpl(
             .where(
                 nightStudyEntity.type.eq(type),
                 nightStudyEntity.endAt.goe(today),
-                status?.let { nightStudyEntity.status.eq(it) }
+                status?.let { nightStudyEntity.status.eq(it) },
+                hideByActiveProjectCondition(type)
             )
             .offset(pageable.offset)
             .limit(pageable.pageSize.toLong())
@@ -79,7 +84,8 @@ class NightStudyQueryRepositoryImpl(
             .where(
                 nightStudyEntity.type.eq(type),
                 nightStudyEntity.endAt.goe(today),
-                status?.let { nightStudyEntity.status.eq(it) }
+                status?.let { nightStudyEntity.status.eq(it) },
+                hideByActiveProjectCondition(type)
             )
 
         return PageableExecutionUtils.getPage(content, pageable) { countQuery.fetchOne() ?: 0L }
@@ -95,7 +101,8 @@ class NightStudyQueryRepositoryImpl(
                 nightStudyEntity.type.eq(type),
                 nightStudyEntity.endAt.goe(today),
                 nightStudyMemberEntity.userId.`in`(userIds),
-                status?.let { nightStudyEntity.status.eq(it) }
+                status?.let { nightStudyEntity.status.eq(it) },
+                hideByActiveProjectCondition(type)
             )
             .distinct()
             .offset(pageable.offset)
@@ -110,7 +117,8 @@ class NightStudyQueryRepositoryImpl(
                 nightStudyEntity.type.eq(type),
                 nightStudyEntity.endAt.goe(today),
                 nightStudyMemberEntity.userId.`in`(userIds),
-                status?.let { nightStudyEntity.status.eq(it) }
+                status?.let { nightStudyEntity.status.eq(it) },
+                hideByActiveProjectCondition(type)
             )
 
         return PageableExecutionUtils.getPage(content, pageable) { countQuery.fetchOne() ?: 0L }
@@ -167,5 +175,28 @@ class NightStudyQueryRepositoryImpl(
                 nightStudyEntity.status.ne(NightStudyStatusType.REJECTED)
             )
             .fetchFirst() != null
+    }
+
+    private fun hideByActiveProjectCondition(type: NightStudyType): BooleanExpression? {
+        if (type != NightStudyType.PERSONAL) return null
+
+        val project = QNightStudyEntity("project")
+        val projectMember = QNightStudyMemberEntity("projectMember")
+        val personalMember = QNightStudyMemberEntity("personalMember")
+
+        return JPAExpressions
+            .selectOne()
+            .from(project)
+            .join(projectMember).on(projectMember.nightStudy.eq(project))
+            .join(personalMember).on(personalMember.nightStudy.eq(nightStudyEntity))
+            .where(
+                project.type.eq(NightStudyType.PROJECT),
+                project.status.`in`(NightStudyStatusType.PENDING, NightStudyStatusType.ALLOWED),
+                project.period.eq(nightStudyEntity.period),
+                project.startAt.loe(nightStudyEntity.endAt),
+                project.endAt.goe(nightStudyEntity.startAt),
+                projectMember.userId.eq(personalMember.userId)
+            )
+            .notExists()
     }
 }

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepositoryImpl.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepositoryImpl.kt
@@ -129,6 +129,7 @@ class NightStudyQueryRepositoryImpl(
     override fun existsByUserIdAndPeriodOverlap(
         userId: UUID,
         period: Int,
+        type: NightStudyType,
         startAt: LocalDate,
         endAt: LocalDate
     ): Boolean {
@@ -138,6 +139,7 @@ class NightStudyQueryRepositoryImpl(
             .where(
                 nightStudyMemberEntity.userId.eq(userId),
                 nightStudyEntity.period.eq(period),
+                nightStudyEntity.type.eq(type),
                 nightStudyEntity.startAt.loe(endAt),
                 nightStudyEntity.endAt.goe(startAt),
                 nightStudyEntity.status.ne(NightStudyStatusType.REJECTED)

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyService.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyService.kt
@@ -34,13 +34,13 @@ class NightStudyService(
     fun save(nightStudy: NightStudyEntity, userId: UUID, members: List<UUID>?) {
         if (isBanned(userId)) throw NightStudyBannedException()
 
-        if (hasPeriodOverlap(userId, nightStudy.period, nightStudy.startAt, nightStudy.endAt)) {
+        if (hasPeriodOverlap(userId, nightStudy.period, nightStudy.type, nightStudy.startAt, nightStudy.endAt)) {
             throw PeriodOverlappedException()
         }
 
         members?.forEach { member ->
             if (isBanned(member)) throw NightStudyBannedException()
-            if (hasPeriodOverlap(member, nightStudy.period, nightStudy.startAt, nightStudy.endAt)) {
+            if (hasPeriodOverlap(member, nightStudy.period, nightStudy.type, nightStudy.startAt, nightStudy.endAt)) {
                 throw PeriodOverlappedException()
             }
         }
@@ -146,9 +146,10 @@ class NightStudyService(
     private fun hasPeriodOverlap(
         userId: UUID,
         period: Int,
+        type: NightStudyType,
         startAt: LocalDate,
         endAt: LocalDate
     ): Boolean {
-        return nightStudyQueryRepository.existsByUserIdAndPeriodOverlap(userId, period, startAt, endAt)
+        return nightStudyQueryRepository.existsByUserIdAndPeriodOverlap(userId, period, type, startAt, endAt)
     }
 }

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyService.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyService.kt
@@ -105,7 +105,17 @@ class NightStudyService(
     }
 
     fun allow(publicId: UUID) {
-        getByPublicId(publicId).allow()
+        val ns = getByPublicId(publicId)
+        val wasAlreadyAllowed = ns.status == NightStudyStatusType.ALLOWED
+        ns.allow()
+        if (ns.type == NightStudyType.PROJECT && !wasAlreadyAllowed) {
+            val memberIds = nightStudyMemberQueryRepository.findAllUserIdsByNightStudy(ns)
+            if (memberIds.isEmpty()) return
+            val targets = nightStudyQueryRepository.findActivePersonalsByUserIdsAndPeriodOverlap(
+                memberIds, ns.period, ns.startAt, ns.endAt
+            )
+            targets.forEach { it.reject("프로젝트 심자로 대체됨") }
+        }
     }
 
     fun reject(publicId: UUID, rejectionReason: String) {


### PR DESCRIPTION
## 변경 내용
PROJECT 우선/PERSONAL fallback 정책을 구현했습니다.

1. 중복 검사 조건 변경: `(userId, period)` → `(userId, period, type)` 기준으로 변경. 같은 period에 PROJECT/PERSONAL 동시 신청 허용, 동일 type+period 중복은 계속 차단.
2. 관리자 목록 노출 정책: 동일 (userId, period, 기간 겹침)에 PROJECT가 PENDING/ALLOWED 상태인 경우 PERSONAL 숨김. PROJECT가 REJECTED 되면 PERSONAL 자동 노출.
3. PROJECT 승인 cascade: PROJECT가 ALLOWED로 승인되면 해당 멤버들의 동일 (period, 기간 겹침) PERSONAL 신청을 자동 REJECTED 처리. rejectionReason: `"프로젝트 심자로 대체됨"`

## 관련 이슈
- Closes #142

## 테스트 방법
- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 완료
- [x] 수동 테스트 완료
  - 같은 유저가 동일 period에 PROJECT + PERSONAL 동시 신청 → 둘 다 성공
  - 동일 type+period 중복 신청 → 차단
  - PROJECT PENDING 상태에서 관리자 목록 PERSONAL 조회 → 숨김
  - PROJECT REJECTED 시 PERSONAL 다시 노출
  - PROJECT ALLOWED 승인 → 활성 PERSONAL 자동 REJECTED, 사유 정확
  - 이미 ALLOWED인 PROJECT 재승인 → cascade 재실행 안 됨

## 체크리스트
- [ ] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [ ] 자체 코드 리뷰를 완료했습니다
- [ ] 변경 사항에 대한 테스트를 추가했습니다
- [ ] Breaking Changes가 없습니다

## 기타 사항
선행 작업 #133(심자 기간 중복 검사 로직 수정) 이후 기준으로 작업했습니다.
학생이 PROJECT를 직접 취소(cancel)하는 경우의 fallback은 본 PR 범위 제외입니다.