### PR TITLE
feat: 심자 승인 인원수 조회 API 추가

### DIFF
--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/NightStudyUseCase.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/NightStudyUseCase.kt
@@ -102,23 +102,23 @@ class NightStudyUseCase (
 
     fun countApproved(): Response<NightStudyApprovedCountResponse> {
         val counts = nightStudyService.countAllowedMembersGroupByTypeAndPeriod()
-
-        fun countFor(type: NightStudyType) = NightStudyApprovedCountResponse.PeriodCount(
-            period1 = counts[type to 1] ?: 0,
-            period2 = counts[type to 2] ?: 0,
-        )
-
-        val personal = countFor(NightStudyType.PERSONAL)
-        val project = countFor(NightStudyType.PROJECT)
-        val response = NightStudyApprovedCountResponse(
-            personal = personal,
-            project = project,
-            total = NightStudyApprovedCountResponse.PeriodCount(
-                period1 = personal.period1 + project.period1,
-                period2 = personal.period2 + project.period2,
+        val byType = NightStudyType.entries.associateWith { type ->
+            NightStudyApprovedCountResponse.PeriodCount(
+                period1 = counts[type to 1] ?: 0,
+                period2 = counts[type to 2] ?: 0,
+            )
+        }
+        return Response.ok(
+            "심자 승인 인원수를 조회했어요.",
+            NightStudyApprovedCountResponse(
+                personal = byType.getValue(NightStudyType.PERSONAL),
+                project = byType.getValue(NightStudyType.PROJECT),
+                total = NightStudyApprovedCountResponse.PeriodCount(
+                    period1 = byType.values.sumOf { it.period1 },
+                    period2 = byType.values.sumOf { it.period2 },
+                ),
             ),
         )
-        return Response.ok("심자 승인 인원수를 조회했어요.", response)
     }
 
     fun findById(id: UUID): Response<NightStudyApplicationResponse> {

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/NightStudyUseCase.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/NightStudyUseCase.kt
@@ -104,8 +104,8 @@ class NightStudyUseCase (
         val counts = nightStudyService.countAllowedMembersGroupByTypeAndPeriod()
 
         fun countFor(type: NightStudyType) = NightStudyApprovedCountResponse.PeriodCount(
-            period1 = counts[type to 1] ?: 0L,
-            period2 = counts[type to 2] ?: 0L,
+            period1 = counts[type to 1] ?: 0,
+            period2 = counts[type to 2] ?: 0,
         )
 
         val personal = countFor(NightStudyType.PERSONAL)

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/NightStudyUseCase.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/NightStudyUseCase.kt
@@ -6,6 +6,7 @@ import com.b1nd.dodamdodam.core.security.passport.requireUserId
 import com.b1nd.dodamdodam.nightstudy.application.nightstudy.data.request.PersonalNightStudyApplyRequest
 import com.b1nd.dodamdodam.nightstudy.application.nightstudy.data.request.ProjectNightStudyApplyRequest
 import com.b1nd.dodamdodam.nightstudy.application.nightstudy.data.response.NightStudyApplicationResponse
+import com.b1nd.dodamdodam.nightstudy.application.nightstudy.data.response.NightStudyApprovedCountResponse
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.command.NightStudyWithMembersCommand
 import com.b1nd.dodamdodam.nightstudy.application.nightstudy.data.response.NightStudyApplicantResponse
 import com.b1nd.dodamdodam.nightstudy.application.nightstudy.data.response.PersonalNightStudyResponse
@@ -97,6 +98,27 @@ class NightStudyUseCase (
                 hasNext = nightStudiesPage.hasNext()
             )
         )
+    }
+
+    fun countApproved(): Response<NightStudyApprovedCountResponse> {
+        val counts = nightStudyService.countAllowedMembersGroupByTypeAndPeriod()
+
+        fun countFor(type: NightStudyType) = NightStudyApprovedCountResponse.PeriodCount(
+            period1 = counts[type to 1] ?: 0L,
+            period2 = counts[type to 2] ?: 0L,
+        )
+
+        val personal = countFor(NightStudyType.PERSONAL)
+        val project = countFor(NightStudyType.PROJECT)
+        val response = NightStudyApprovedCountResponse(
+            personal = personal,
+            project = project,
+            total = NightStudyApprovedCountResponse.PeriodCount(
+                period1 = personal.period1 + project.period1,
+                period2 = personal.period2 + project.period2,
+            ),
+        )
+        return Response.ok("심자 승인 인원수를 조회했어요.", response)
     }
 
     fun findById(id: UUID): Response<NightStudyApplicationResponse> {

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/data/response/NightStudyApprovedCountResponse.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/data/response/NightStudyApprovedCountResponse.kt
@@ -1,0 +1,12 @@
+package com.b1nd.dodamdodam.nightstudy.application.nightstudy.data.response
+
+data class NightStudyApprovedCountResponse(
+    val personal: PeriodCount,
+    val project: PeriodCount,
+    val total: PeriodCount,
+) {
+    data class PeriodCount(
+        val period1: Long,
+        val period2: Long,
+    )
+}

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/data/response/NightStudyApprovedCountResponse.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/data/response/NightStudyApprovedCountResponse.kt
@@ -6,7 +6,7 @@ data class NightStudyApprovedCountResponse(
     val total: PeriodCount,
 ) {
     data class PeriodCount(
-        val period1: Long,
-        val period2: Long,
+        val period1: Int,
+        val period2: Int,
     )
 }

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepository.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepository.kt
@@ -14,6 +14,7 @@ interface NightStudyQueryRepository {
     fun findAllByUserIdAndType(userId: UUID, type: NightStudyType): List<NightStudyEntity>
     fun findAllByTypeAndStatus(type: NightStudyType, status: NightStudyStatusType?, pageable: Pageable): Page<NightStudyEntity>
     fun findAllByTypeAndUserIdsAndStatus(type: NightStudyType, userIds: List<UUID>, status: NightStudyStatusType?, pageable: Pageable): Page<NightStudyEntity>
+    fun countAllowedMembersGroupByTypeAndPeriod(): Map<Pair<NightStudyType, Int>, Long>
     fun existsByPublicIdAndUserId(publicId: UUID, userId: UUID): Boolean
     fun existsByUserIdAndPeriodOverlap(userId: UUID, period: Int, type: NightStudyType, startAt: LocalDate, endAt: LocalDate): Boolean
     fun existsByRoomAndPeriodOverlap(roomId: Long, period: Int, startAt: LocalDate, endAt: LocalDate, excludeNightStudyId: Long): Boolean

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepository.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepository.kt
@@ -14,7 +14,7 @@ interface NightStudyQueryRepository {
     fun findAllByUserIdAndType(userId: UUID, type: NightStudyType): List<NightStudyEntity>
     fun findAllByTypeAndStatus(type: NightStudyType, status: NightStudyStatusType?, pageable: Pageable): Page<NightStudyEntity>
     fun findAllByTypeAndUserIdsAndStatus(type: NightStudyType, userIds: List<UUID>, status: NightStudyStatusType?, pageable: Pageable): Page<NightStudyEntity>
-    fun countAllowedMembersGroupByTypeAndPeriod(): Map<Pair<NightStudyType, Int>, Long>
+    fun countAllowedMembersGroupByTypeAndPeriod(): Map<Pair<NightStudyType, Int>, Int>
     fun existsByPublicIdAndUserId(publicId: UUID, userId: UUID): Boolean
     fun existsByUserIdAndPeriodOverlap(userId: UUID, period: Int, type: NightStudyType, startAt: LocalDate, endAt: LocalDate): Boolean
     fun existsByRoomAndPeriodOverlap(roomId: Long, period: Int, startAt: LocalDate, endAt: LocalDate, excludeNightStudyId: Long): Boolean

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepositoryImpl.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepositoryImpl.kt
@@ -124,7 +124,7 @@ class NightStudyQueryRepositoryImpl(
         return PageableExecutionUtils.getPage(content, pageable) { countQuery.fetchOne() ?: 0L }
     }
 
-    override fun countAllowedMembersGroupByTypeAndPeriod(): Map<Pair<NightStudyType, Int>, Long> {
+    override fun countAllowedMembersGroupByTypeAndPeriod(): Map<Pair<NightStudyType, Int>, Int> {
         val today = LocalDate.now()
         val distinctUser = nightStudyMemberEntity.userId.countDistinct()
 
@@ -141,7 +141,7 @@ class NightStudyQueryRepositoryImpl(
             .associate { tuple ->
                 val type = tuple.get(nightStudyEntity.type)!!
                 val period = tuple.get(nightStudyEntity.period) ?: 0
-                (type to period) to (tuple.get(distinctUser) ?: 0L)
+                (type to period) to (tuple.get(distinctUser)?.toInt() ?: 0)
             }
     }
 

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepositoryImpl.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepositoryImpl.kt
@@ -124,6 +124,27 @@ class NightStudyQueryRepositoryImpl(
         return PageableExecutionUtils.getPage(content, pageable) { countQuery.fetchOne() ?: 0L }
     }
 
+    override fun countAllowedMembersGroupByTypeAndPeriod(): Map<Pair<NightStudyType, Int>, Long> {
+        val today = LocalDate.now()
+        val distinctUser = nightStudyMemberEntity.userId.countDistinct()
+
+        return queryFactory
+            .select(nightStudyEntity.type, nightStudyEntity.period, distinctUser)
+            .from(nightStudyMemberEntity)
+            .join(nightStudyMemberEntity.nightStudy, nightStudyEntity)
+            .where(
+                nightStudyEntity.status.eq(NightStudyStatusType.ALLOWED),
+                nightStudyEntity.endAt.goe(today),
+            )
+            .groupBy(nightStudyEntity.type, nightStudyEntity.period)
+            .fetch()
+            .associate { tuple ->
+                val type = tuple.get(nightStudyEntity.type)!!
+                val period = tuple.get(nightStudyEntity.period) ?: 0
+                (type to period) to (tuple.get(distinctUser) ?: 0L)
+            }
+    }
+
     override fun existsByPublicIdAndUserId(publicId: UUID, userId: UUID): Boolean {
         return queryFactory.selectOne()
             .from(nightStudyMemberEntity)

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyService.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyService.kt
@@ -61,6 +61,10 @@ class NightStudyService(
         return nightStudyQueryRepository.findAllByUserIdAndType(userId, type)
     }
 
+    fun countAllowedMembersGroupByTypeAndPeriod(): Map<Pair<NightStudyType, Int>, Long> {
+        return nightStudyQueryRepository.countAllowedMembersGroupByTypeAndPeriod()
+    }
+
     fun searchByType(type: NightStudyType, userIds: List<UUID>?, status: NightStudyStatusType?, pageable: Pageable): Page<NightStudyEntity> {
         return if (userIds != null) {
             nightStudyQueryRepository.findAllByTypeAndUserIdsAndStatus(type, userIds, status, pageable)

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyService.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyService.kt
@@ -61,7 +61,7 @@ class NightStudyService(
         return nightStudyQueryRepository.findAllByUserIdAndType(userId, type)
     }
 
-    fun countAllowedMembersGroupByTypeAndPeriod(): Map<Pair<NightStudyType, Int>, Long> {
+    fun countAllowedMembersGroupByTypeAndPeriod(): Map<Pair<NightStudyType, Int>, Int> {
         return nightStudyQueryRepository.countAllowedMembersGroupByTypeAndPeriod()
     }
 

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/presentation/nightstudy/NightStudyController.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/presentation/nightstudy/NightStudyController.kt
@@ -9,6 +9,7 @@ import com.b1nd.dodamdodam.nightstudy.application.nightstudy.data.request.Person
 import com.b1nd.dodamdodam.nightstudy.application.nightstudy.data.request.ProjectNightStudyApplyRequest
 import com.b1nd.dodamdodam.nightstudy.application.nightstudy.data.request.RejectNightStudyRequest
 import com.b1nd.dodamdodam.nightstudy.application.nightstudy.data.response.NightStudyApplicationResponse
+import com.b1nd.dodamdodam.nightstudy.application.nightstudy.data.response.NightStudyApprovedCountResponse
 import com.b1nd.dodamdodam.nightstudy.application.nightstudy.data.response.PersonalNightStudyResponse
 import com.b1nd.dodamdodam.nightstudy.application.nightstudy.data.response.ProjectNightStudyResponse
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.enumeration.NightStudyStatusType
@@ -51,6 +52,11 @@ class NightStudyController(
     @GetMapping("/applications")
     fun findAllByType(@RequestParam type: NightStudyType, @RequestParam(required = false) keyword: String?, @RequestParam(required = false) status: NightStudyStatusType?, pageable: Pageable): Response<InfinityScrollPageResponse<NightStudyApplicationResponse>> =
         nightStudyUseCase.searchAllByType(type, keyword, status, pageable)
+
+    @UserAccess(roles = [RoleType.DORMITORY_MANAGER])
+    @GetMapping("/applications/count")
+    fun countApproved(): Response<NightStudyApprovedCountResponse> =
+        nightStudyUseCase.countApproved()
 
     @UserAccess(roles = [RoleType.DORMITORY_MANAGER])
     @GetMapping("/applications/{id}")


### PR DESCRIPTION
## 변경 내용

심야자습 승인 인원수를 한 번에 조회할 수 있는 API를 추가했습니다.

- `GET /applications/count` (DORMITORY_MANAGER 권한)
- 응답: personal / project / total 각각의 period1, period2 카운트
- 조건: status = ALLOWED + endAt >= 오늘, night_study_members 기준 distinct 유저 카운트
- 단일 그룹 쿼리(type + period)로 1회만 조회, 합계는 서버에서 합산
- PR #142
ALLOWED 상태에서 PERSONAL/PROJECT 중복 사용자가 발생하지 않아 단순 합산이 physical presence와 일치합니다

```json
{
  "status": 200,
  "message": "심자 승인 인원수를 조회했어요.",
  "data": {
    "personal": { "period1": 20, "period2": 15 },
    "project":  { "period1": 10, "period2": 10 },
    "total":    { "period1": 30, "period2": 25 }
  }
}
```

## 관련 이슈

- Resolves #154

## 테스트 방법

- [x] 수동 테스트 완료

1. 자치위원 계정으로 로그인
2. `GET /applications/count` 호출
3. 기존 `GET /applications?type=PERSONAL&status=ALLOWED` 목록을 끝까지 넘기며 센 수와
`personal.period1`, `personal.period2` 값이 일치하는지 확인
4. PROJECT도 동일 방식으로 검증

## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 완료했습니다
- [x] Breaking Changes가 없습니다

## 기타 사항

- `type` 파라미터 없는 단일 엔드포인트로, 자치위원회 요구("심자 1/2별 전체 승인 인원")에 맞춰
personal/project/total을 한 번에 반환합니다
- 기존 목록 API의 `hideByActiveProjectCondition`은 카운트에서 적용하지 않았습니다.
PENDING PROJECT + ALLOWED PERSONAL 학생은 실제 개인 자습실에 있으므로 카운트에 포함되어야 합니다