### PR TITLE
Develop

### DIFF
--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/NightStudyUseCase.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/NightStudyUseCase.kt
@@ -102,23 +102,23 @@ class NightStudyUseCase (
 
     fun countApproved(): Response<NightStudyApprovedCountResponse> {
         val counts = nightStudyService.countAllowedMembersGroupByTypeAndPeriod()
-
-        fun countFor(type: NightStudyType) = NightStudyApprovedCountResponse.PeriodCount(
-            period1 = counts[type to 1] ?: 0,
-            period2 = counts[type to 2] ?: 0,
-        )
-
-        val personal = countFor(NightStudyType.PERSONAL)
-        val project = countFor(NightStudyType.PROJECT)
-        val response = NightStudyApprovedCountResponse(
-            personal = personal,
-            project = project,
-            total = NightStudyApprovedCountResponse.PeriodCount(
-                period1 = personal.period1 + project.period1,
-                period2 = personal.period2 + project.period2,
+        val byType = NightStudyType.entries.associateWith { type ->
+            NightStudyApprovedCountResponse.PeriodCount(
+                period1 = counts[type to 1] ?: 0,
+                period2 = counts[type to 2] ?: 0,
+            )
+        }
+        return Response.ok(
+            "심자 승인 인원수를 조회했어요.",
+            NightStudyApprovedCountResponse(
+                personal = byType.getValue(NightStudyType.PERSONAL),
+                project = byType.getValue(NightStudyType.PROJECT),
+                total = NightStudyApprovedCountResponse.PeriodCount(
+                    period1 = byType.values.sumOf { it.period1 },
+                    period2 = byType.values.sumOf { it.period2 },
+                ),
             ),
         )
-        return Response.ok("심자 승인 인원수를 조회했어요.", response)
     }
 
     fun findById(id: UUID): Response<NightStudyApplicationResponse> {

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/NightStudyUseCase.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/NightStudyUseCase.kt
@@ -104,8 +104,8 @@ class NightStudyUseCase (
         val counts = nightStudyService.countAllowedMembersGroupByTypeAndPeriod()
 
         fun countFor(type: NightStudyType) = NightStudyApprovedCountResponse.PeriodCount(
-            period1 = counts[type to 1] ?: 0L,
-            period2 = counts[type to 2] ?: 0L,
+            period1 = counts[type to 1] ?: 0,
+            period2 = counts[type to 2] ?: 0,
         )
 
         val personal = countFor(NightStudyType.PERSONAL)

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/NightStudyUseCase.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/NightStudyUseCase.kt
@@ -6,6 +6,7 @@ import com.b1nd.dodamdodam.core.security.passport.requireUserId
 import com.b1nd.dodamdodam.nightstudy.application.nightstudy.data.request.PersonalNightStudyApplyRequest
 import com.b1nd.dodamdodam.nightstudy.application.nightstudy.data.request.ProjectNightStudyApplyRequest
 import com.b1nd.dodamdodam.nightstudy.application.nightstudy.data.response.NightStudyApplicationResponse
+import com.b1nd.dodamdodam.nightstudy.application.nightstudy.data.response.NightStudyApprovedCountResponse
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.command.NightStudyWithMembersCommand
 import com.b1nd.dodamdodam.nightstudy.application.nightstudy.data.response.NightStudyApplicantResponse
 import com.b1nd.dodamdodam.nightstudy.application.nightstudy.data.response.PersonalNightStudyResponse
@@ -97,6 +98,27 @@ class NightStudyUseCase (
                 hasNext = nightStudiesPage.hasNext()
             )
         )
+    }
+
+    fun countApproved(): Response<NightStudyApprovedCountResponse> {
+        val counts = nightStudyService.countAllowedMembersGroupByTypeAndPeriod()
+
+        fun countFor(type: NightStudyType) = NightStudyApprovedCountResponse.PeriodCount(
+            period1 = counts[type to 1] ?: 0L,
+            period2 = counts[type to 2] ?: 0L,
+        )
+
+        val personal = countFor(NightStudyType.PERSONAL)
+        val project = countFor(NightStudyType.PROJECT)
+        val response = NightStudyApprovedCountResponse(
+            personal = personal,
+            project = project,
+            total = NightStudyApprovedCountResponse.PeriodCount(
+                period1 = personal.period1 + project.period1,
+                period2 = personal.period2 + project.period2,
+            ),
+        )
+        return Response.ok("심자 승인 인원수를 조회했어요.", response)
     }
 
     fun findById(id: UUID): Response<NightStudyApplicationResponse> {

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/data/response/NightStudyApprovedCountResponse.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/data/response/NightStudyApprovedCountResponse.kt
@@ -1,0 +1,12 @@
+package com.b1nd.dodamdodam.nightstudy.application.nightstudy.data.response
+
+data class NightStudyApprovedCountResponse(
+    val personal: PeriodCount,
+    val project: PeriodCount,
+    val total: PeriodCount,
+) {
+    data class PeriodCount(
+        val period1: Long,
+        val period2: Long,
+    )
+}

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/data/response/NightStudyApprovedCountResponse.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/data/response/NightStudyApprovedCountResponse.kt
@@ -6,7 +6,7 @@ data class NightStudyApprovedCountResponse(
     val total: PeriodCount,
 ) {
     data class PeriodCount(
-        val period1: Long,
-        val period2: Long,
+        val period1: Int,
+        val period2: Int,
     )
 }

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepository.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepository.kt
@@ -17,4 +17,5 @@ interface NightStudyQueryRepository {
     fun existsByPublicIdAndUserId(publicId: UUID, userId: UUID): Boolean
     fun existsByUserIdAndPeriodOverlap(userId: UUID, period: Int, type: NightStudyType, startAt: LocalDate, endAt: LocalDate): Boolean
     fun existsByRoomAndPeriodOverlap(roomId: Long, period: Int, startAt: LocalDate, endAt: LocalDate, excludeNightStudyId: Long): Boolean
+    fun findActivePersonalsByUserIdsAndPeriodOverlap(userIds: List<UUID>, period: Int, startAt: LocalDate, endAt: LocalDate): List<NightStudyEntity>
 }

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepository.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepository.kt
@@ -15,6 +15,6 @@ interface NightStudyQueryRepository {
     fun findAllByTypeAndStatus(type: NightStudyType, status: NightStudyStatusType?, pageable: Pageable): Page<NightStudyEntity>
     fun findAllByTypeAndUserIdsAndStatus(type: NightStudyType, userIds: List<UUID>, status: NightStudyStatusType?, pageable: Pageable): Page<NightStudyEntity>
     fun existsByPublicIdAndUserId(publicId: UUID, userId: UUID): Boolean
-    fun existsByUserIdAndPeriodOverlap(userId: UUID, period: Int, startAt: LocalDate, endAt: LocalDate): Boolean
+    fun existsByUserIdAndPeriodOverlap(userId: UUID, period: Int, type: NightStudyType, startAt: LocalDate, endAt: LocalDate): Boolean
     fun existsByRoomAndPeriodOverlap(roomId: Long, period: Int, startAt: LocalDate, endAt: LocalDate, excludeNightStudyId: Long): Boolean
 }

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepository.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepository.kt
@@ -14,6 +14,7 @@ interface NightStudyQueryRepository {
     fun findAllByUserIdAndType(userId: UUID, type: NightStudyType): List<NightStudyEntity>
     fun findAllByTypeAndStatus(type: NightStudyType, status: NightStudyStatusType?, pageable: Pageable): Page<NightStudyEntity>
     fun findAllByTypeAndUserIdsAndStatus(type: NightStudyType, userIds: List<UUID>, status: NightStudyStatusType?, pageable: Pageable): Page<NightStudyEntity>
+    fun countAllowedMembersGroupByTypeAndPeriod(): Map<Pair<NightStudyType, Int>, Long>
     fun existsByPublicIdAndUserId(publicId: UUID, userId: UUID): Boolean
     fun existsByUserIdAndPeriodOverlap(userId: UUID, period: Int, type: NightStudyType, startAt: LocalDate, endAt: LocalDate): Boolean
     fun existsByRoomAndPeriodOverlap(roomId: Long, period: Int, startAt: LocalDate, endAt: LocalDate, excludeNightStudyId: Long): Boolean

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepository.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepository.kt
@@ -14,7 +14,7 @@ interface NightStudyQueryRepository {
     fun findAllByUserIdAndType(userId: UUID, type: NightStudyType): List<NightStudyEntity>
     fun findAllByTypeAndStatus(type: NightStudyType, status: NightStudyStatusType?, pageable: Pageable): Page<NightStudyEntity>
     fun findAllByTypeAndUserIdsAndStatus(type: NightStudyType, userIds: List<UUID>, status: NightStudyStatusType?, pageable: Pageable): Page<NightStudyEntity>
-    fun countAllowedMembersGroupByTypeAndPeriod(): Map<Pair<NightStudyType, Int>, Long>
+    fun countAllowedMembersGroupByTypeAndPeriod(): Map<Pair<NightStudyType, Int>, Int>
     fun existsByPublicIdAndUserId(publicId: UUID, userId: UUID): Boolean
     fun existsByUserIdAndPeriodOverlap(userId: UUID, period: Int, type: NightStudyType, startAt: LocalDate, endAt: LocalDate): Boolean
     fun existsByRoomAndPeriodOverlap(roomId: Long, period: Int, startAt: LocalDate, endAt: LocalDate, excludeNightStudyId: Long): Boolean

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepositoryImpl.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepositoryImpl.kt
@@ -124,7 +124,7 @@ class NightStudyQueryRepositoryImpl(
         return PageableExecutionUtils.getPage(content, pageable) { countQuery.fetchOne() ?: 0L }
     }
 
-    override fun countAllowedMembersGroupByTypeAndPeriod(): Map<Pair<NightStudyType, Int>, Long> {
+    override fun countAllowedMembersGroupByTypeAndPeriod(): Map<Pair<NightStudyType, Int>, Int> {
         val today = LocalDate.now()
         val distinctUser = nightStudyMemberEntity.userId.countDistinct()
 
@@ -141,7 +141,7 @@ class NightStudyQueryRepositoryImpl(
             .associate { tuple ->
                 val type = tuple.get(nightStudyEntity.type)!!
                 val period = tuple.get(nightStudyEntity.period) ?: 0
-                (type to period) to (tuple.get(distinctUser) ?: 0L)
+                (type to period) to (tuple.get(distinctUser)?.toInt() ?: 0)
             }
     }
 

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepositoryImpl.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepositoryImpl.kt
@@ -124,6 +124,27 @@ class NightStudyQueryRepositoryImpl(
         return PageableExecutionUtils.getPage(content, pageable) { countQuery.fetchOne() ?: 0L }
     }
 
+    override fun countAllowedMembersGroupByTypeAndPeriod(): Map<Pair<NightStudyType, Int>, Long> {
+        val today = LocalDate.now()
+        val distinctUser = nightStudyMemberEntity.userId.countDistinct()
+
+        return queryFactory
+            .select(nightStudyEntity.type, nightStudyEntity.period, distinctUser)
+            .from(nightStudyMemberEntity)
+            .join(nightStudyMemberEntity.nightStudy, nightStudyEntity)
+            .where(
+                nightStudyEntity.status.eq(NightStudyStatusType.ALLOWED),
+                nightStudyEntity.endAt.goe(today),
+            )
+            .groupBy(nightStudyEntity.type, nightStudyEntity.period)
+            .fetch()
+            .associate { tuple ->
+                val type = tuple.get(nightStudyEntity.type)!!
+                val period = tuple.get(nightStudyEntity.period) ?: 0
+                (type to period) to (tuple.get(distinctUser) ?: 0L)
+            }
+    }
+
     override fun existsByPublicIdAndUserId(publicId: UUID, userId: UUID): Boolean {
         return queryFactory.selectOne()
             .from(nightStudyMemberEntity)

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepositoryImpl.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepositoryImpl.kt
@@ -177,6 +177,29 @@ class NightStudyQueryRepositoryImpl(
             .fetchFirst() != null
     }
 
+    override fun findActivePersonalsByUserIdsAndPeriodOverlap(
+        userIds: List<UUID>,
+        period: Int,
+        startAt: LocalDate,
+        endAt: LocalDate
+    ): List<NightStudyEntity> {
+        if (userIds.isEmpty()) return emptyList()
+
+        return queryFactory.select(nightStudyEntity)
+            .from(nightStudyMemberEntity)
+            .join(nightStudyMemberEntity.nightStudy, nightStudyEntity)
+            .where(
+                nightStudyEntity.type.eq(NightStudyType.PERSONAL),
+                nightStudyEntity.status.`in`(NightStudyStatusType.PENDING, NightStudyStatusType.ALLOWED),
+                nightStudyEntity.period.eq(period),
+                nightStudyEntity.startAt.loe(endAt),
+                nightStudyEntity.endAt.goe(startAt),
+                nightStudyMemberEntity.userId.`in`(userIds)
+            )
+            .distinct()
+            .fetch()
+    }
+
     private fun hideByActiveProjectCondition(type: NightStudyType): BooleanExpression? {
         if (type != NightStudyType.PERSONAL) return null
 

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepositoryImpl.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepositoryImpl.kt
@@ -1,11 +1,15 @@
 package com.b1nd.dodamdodam.nightstudy.domain.nightstudy.repository.nightStudy
 
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.entity.NightStudyEntity
+import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.entity.QNightStudyEntity
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.entity.QNightStudyEntity.nightStudyEntity
+import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.entity.QNightStudyMemberEntity
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.entity.QNightStudyMemberEntity.nightStudyMemberEntity
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.enumeration.NightStudyStatusType
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.enumeration.NightStudyType
 import com.b1nd.dodamdodam.nightstudy.domain.room.entity.QProjectRoomEntity
+import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.jpa.JPAExpressions
 import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
@@ -67,7 +71,8 @@ class NightStudyQueryRepositoryImpl(
             .where(
                 nightStudyEntity.type.eq(type),
                 nightStudyEntity.endAt.goe(today),
-                status?.let { nightStudyEntity.status.eq(it) }
+                status?.let { nightStudyEntity.status.eq(it) },
+                hideByActiveProjectCondition(type)
             )
             .offset(pageable.offset)
             .limit(pageable.pageSize.toLong())
@@ -79,7 +84,8 @@ class NightStudyQueryRepositoryImpl(
             .where(
                 nightStudyEntity.type.eq(type),
                 nightStudyEntity.endAt.goe(today),
-                status?.let { nightStudyEntity.status.eq(it) }
+                status?.let { nightStudyEntity.status.eq(it) },
+                hideByActiveProjectCondition(type)
             )
 
         return PageableExecutionUtils.getPage(content, pageable) { countQuery.fetchOne() ?: 0L }
@@ -95,7 +101,8 @@ class NightStudyQueryRepositoryImpl(
                 nightStudyEntity.type.eq(type),
                 nightStudyEntity.endAt.goe(today),
                 nightStudyMemberEntity.userId.`in`(userIds),
-                status?.let { nightStudyEntity.status.eq(it) }
+                status?.let { nightStudyEntity.status.eq(it) },
+                hideByActiveProjectCondition(type)
             )
             .distinct()
             .offset(pageable.offset)
@@ -110,7 +117,8 @@ class NightStudyQueryRepositoryImpl(
                 nightStudyEntity.type.eq(type),
                 nightStudyEntity.endAt.goe(today),
                 nightStudyMemberEntity.userId.`in`(userIds),
-                status?.let { nightStudyEntity.status.eq(it) }
+                status?.let { nightStudyEntity.status.eq(it) },
+                hideByActiveProjectCondition(type)
             )
 
         return PageableExecutionUtils.getPage(content, pageable) { countQuery.fetchOne() ?: 0L }
@@ -167,5 +175,28 @@ class NightStudyQueryRepositoryImpl(
                 nightStudyEntity.status.ne(NightStudyStatusType.REJECTED)
             )
             .fetchFirst() != null
+    }
+
+    private fun hideByActiveProjectCondition(type: NightStudyType): BooleanExpression? {
+        if (type != NightStudyType.PERSONAL) return null
+
+        val project = QNightStudyEntity("project")
+        val projectMember = QNightStudyMemberEntity("projectMember")
+        val personalMember = QNightStudyMemberEntity("personalMember")
+
+        return JPAExpressions
+            .selectOne()
+            .from(project)
+            .join(projectMember).on(projectMember.nightStudy.eq(project))
+            .join(personalMember).on(personalMember.nightStudy.eq(nightStudyEntity))
+            .where(
+                project.type.eq(NightStudyType.PROJECT),
+                project.status.`in`(NightStudyStatusType.PENDING, NightStudyStatusType.ALLOWED),
+                project.period.eq(nightStudyEntity.period),
+                project.startAt.loe(nightStudyEntity.endAt),
+                project.endAt.goe(nightStudyEntity.startAt),
+                projectMember.userId.eq(personalMember.userId)
+            )
+            .notExists()
     }
 }

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepositoryImpl.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepositoryImpl.kt
@@ -129,6 +129,7 @@ class NightStudyQueryRepositoryImpl(
     override fun existsByUserIdAndPeriodOverlap(
         userId: UUID,
         period: Int,
+        type: NightStudyType,
         startAt: LocalDate,
         endAt: LocalDate
     ): Boolean {
@@ -138,6 +139,7 @@ class NightStudyQueryRepositoryImpl(
             .where(
                 nightStudyMemberEntity.userId.eq(userId),
                 nightStudyEntity.period.eq(period),
+                nightStudyEntity.type.eq(type),
                 nightStudyEntity.startAt.loe(endAt),
                 nightStudyEntity.endAt.goe(startAt),
                 nightStudyEntity.status.ne(NightStudyStatusType.REJECTED)

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyService.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyService.kt
@@ -34,13 +34,13 @@ class NightStudyService(
     fun save(nightStudy: NightStudyEntity, userId: UUID, members: List<UUID>?) {
         if (isBanned(userId)) throw NightStudyBannedException()
 
-        if (hasPeriodOverlap(userId, nightStudy.period, nightStudy.startAt, nightStudy.endAt)) {
+        if (hasPeriodOverlap(userId, nightStudy.period, nightStudy.type, nightStudy.startAt, nightStudy.endAt)) {
             throw PeriodOverlappedException()
         }
 
         members?.forEach { member ->
             if (isBanned(member)) throw NightStudyBannedException()
-            if (hasPeriodOverlap(member, nightStudy.period, nightStudy.startAt, nightStudy.endAt)) {
+            if (hasPeriodOverlap(member, nightStudy.period, nightStudy.type, nightStudy.startAt, nightStudy.endAt)) {
                 throw PeriodOverlappedException()
             }
         }
@@ -146,9 +146,10 @@ class NightStudyService(
     private fun hasPeriodOverlap(
         userId: UUID,
         period: Int,
+        type: NightStudyType,
         startAt: LocalDate,
         endAt: LocalDate
     ): Boolean {
-        return nightStudyQueryRepository.existsByUserIdAndPeriodOverlap(userId, period, startAt, endAt)
+        return nightStudyQueryRepository.existsByUserIdAndPeriodOverlap(userId, period, type, startAt, endAt)
     }
 }

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyService.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyService.kt
@@ -105,7 +105,17 @@ class NightStudyService(
     }
 
     fun allow(publicId: UUID) {
-        getByPublicId(publicId).allow()
+        val ns = getByPublicId(publicId)
+        val wasAlreadyAllowed = ns.status == NightStudyStatusType.ALLOWED
+        ns.allow()
+        if (ns.type == NightStudyType.PROJECT && !wasAlreadyAllowed) {
+            val memberIds = nightStudyMemberQueryRepository.findAllUserIdsByNightStudy(ns)
+            if (memberIds.isEmpty()) return
+            val targets = nightStudyQueryRepository.findActivePersonalsByUserIdsAndPeriodOverlap(
+                memberIds, ns.period, ns.startAt, ns.endAt
+            )
+            targets.forEach { it.reject("프로젝트 심자로 대체됨") }
+        }
     }
 
     fun reject(publicId: UUID, rejectionReason: String) {

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyService.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyService.kt
@@ -61,6 +61,10 @@ class NightStudyService(
         return nightStudyQueryRepository.findAllByUserIdAndType(userId, type)
     }
 
+    fun countAllowedMembersGroupByTypeAndPeriod(): Map<Pair<NightStudyType, Int>, Long> {
+        return nightStudyQueryRepository.countAllowedMembersGroupByTypeAndPeriod()
+    }
+
     fun searchByType(type: NightStudyType, userIds: List<UUID>?, status: NightStudyStatusType?, pageable: Pageable): Page<NightStudyEntity> {
         return if (userIds != null) {
             nightStudyQueryRepository.findAllByTypeAndUserIdsAndStatus(type, userIds, status, pageable)

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyService.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyService.kt
@@ -61,7 +61,7 @@ class NightStudyService(
         return nightStudyQueryRepository.findAllByUserIdAndType(userId, type)
     }
 
-    fun countAllowedMembersGroupByTypeAndPeriod(): Map<Pair<NightStudyType, Int>, Long> {
+    fun countAllowedMembersGroupByTypeAndPeriod(): Map<Pair<NightStudyType, Int>, Int> {
         return nightStudyQueryRepository.countAllowedMembersGroupByTypeAndPeriod()
     }
 

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/presentation/nightstudy/NightStudyController.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/presentation/nightstudy/NightStudyController.kt
@@ -9,6 +9,7 @@ import com.b1nd.dodamdodam.nightstudy.application.nightstudy.data.request.Person
 import com.b1nd.dodamdodam.nightstudy.application.nightstudy.data.request.ProjectNightStudyApplyRequest
 import com.b1nd.dodamdodam.nightstudy.application.nightstudy.data.request.RejectNightStudyRequest
 import com.b1nd.dodamdodam.nightstudy.application.nightstudy.data.response.NightStudyApplicationResponse
+import com.b1nd.dodamdodam.nightstudy.application.nightstudy.data.response.NightStudyApprovedCountResponse
 import com.b1nd.dodamdodam.nightstudy.application.nightstudy.data.response.PersonalNightStudyResponse
 import com.b1nd.dodamdodam.nightstudy.application.nightstudy.data.response.ProjectNightStudyResponse
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.enumeration.NightStudyStatusType
@@ -51,6 +52,11 @@ class NightStudyController(
     @GetMapping("/applications")
     fun findAllByType(@RequestParam type: NightStudyType, @RequestParam(required = false) keyword: String?, @RequestParam(required = false) status: NightStudyStatusType?, pageable: Pageable): Response<InfinityScrollPageResponse<NightStudyApplicationResponse>> =
         nightStudyUseCase.searchAllByType(type, keyword, status, pageable)
+
+    @UserAccess(roles = [RoleType.DORMITORY_MANAGER])
+    @GetMapping("/applications/count")
+    fun countApproved(): Response<NightStudyApprovedCountResponse> =
+        nightStudyUseCase.countApproved()
 
     @UserAccess(roles = [RoleType.DORMITORY_MANAGER])
     @GetMapping("/applications/{id}")


### PR DESCRIPTION
## 변경 내용
develop 브랜치에 누적된 심자(야간자율학습) 도메인 변경 2건을 main에 반영합니다.

**[#142] PROJECT 우선 / PERSONAL fallback 정책 (PR #153)**
- 중복 검사 기준 확장: (userId, period) → (userId, period, type)
동일 period에 PROJECT + PERSONAL 동시 신청 허용, 동일 type+period 중복은 기존대로 차단
- 관리자 목록 노출 정책: 
동일 유저+기간 겹침에 PROJECT가 PENDING / ALLOWED이면 PERSONAL 숨김, PROJECT REJECTED 시 재노출
- PROJECT 승인 cascade:
PROJECT가 ALLOWED로 승인되면 기간 겹치는 활성 PERSONAL 자동 REJECTED (사유: "프로젝트 심자로 대체됨")
- 이미 ALLOWED인 PROJECT 재승인 시 cascade 중복 실행 방지 가드 포함

**[#154] 심자 승인 인원수 조회 API (PR #155)**
- 신규 엔드포인트: `GET /nightstudy/applications/count` (권한: `DORMITORY_MANAGER`)
- 응답: personal / project / total × period1 / period2 카운트
- 집계 기준: 활성(`endAt >= today`) + ALLOWED 상태의 distinct user 수를 (type, period)로 grouping
- enum 순회로 응답 매핑, 카운트 타입 Int

## 관련 이슈
- Resolves #142
- Resolves #154
- See also #153, #155, #133

## 테스트 방법
- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 완료
- [x] 수동 테스트 완료

**PROJECT/PERSONAL fallback**
- 같은 유저가 동일 period에 PROJECT + PERSONAL 동시 신청 → 둘 다 성공
- 동일 type+period 중복 신청 → 차단
- PROJECT `PENDING` 상태에서 관리자 PERSONAL 목록 조회 → 해당 유저 PERSONAL 숨김
- PROJECT `REJECTED`로 전환 → PERSONAL 다시 노출
- PROJECT `ALLOWED` 승인 → 기간 겹치는 활성 PERSONAL 자동 `REJECTED`, 사유 정확
- 이미 `ALLOWED`인 PROJECT 재승인 → cascade 재실행 안 됨

**승인 인원수 API**
- `GET /nightstudy/applications/count` 호출 → personal / project / total × period1 / period2 응답
- 한 유저가 여러 신청에 속해 있어도 distinct user 기준으로 1로 집계되는지 확인
- endAt 지난 신청은 카운트에서 제외되는지 확인
- `PENDING`/`REJECTED` 신청은 카운트에서 제외되는지 확인
- 권한 없는 사용자 호출 → 차단

## 스크린샷 (UI 변경 시)
해당 없음 (서버 사이드 변경)

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 완료했습니다
- [ ] 변경 사항에 대한 테스트를 추가했습니다
- [x] 문서를 업데이트했습니다 (필요한 경우)
- [x] Breaking Changes가 없습니다 (Repository 시그니처 변경은 내부 호출부만 영향, 외부 API 호환 유지)

## 기타 사항
- `existsByUserIdAndPeriodOverlap`에 type: NightStudyType 파라미터 추가 — 현재 호출처는 `NightStudyService.hasPeriodOverlap` 1곳뿐이며 내부 도메인에 한정됨
- `GET /nightstudy/applications/count`는 `DORMITORY_MANAGER`만 호출 가능
- 카운트 집계 정책: period 그룹별 합산이 total과 일치하지 않을 수 있음 (서로 다른 period에 신청한 유저는 각각 1로 카운트 — 의도된 동작)
- `hideByActiveProjectCondition`은 `JPAExpressions.notExists` 서브쿼리로 구현 — `night_study(period, status, start_at, end_at)`, `night_study_member(user_id)` 인덱스 활용 여부 검토 권장
- 학생이 PROJECT를 직접 cancel할 경우 PERSONAL fallback 복구는 본 PR 범위 외 — 후속 이슈로 분리 필요