### PR TITLE
feat:/nightstudy/ban에 학생정보 추가

### DIFF
--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/ban/BanUseCase.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/ban/BanUseCase.kt
@@ -3,12 +3,16 @@ package com.b1nd.dodamdodam.nightstudy.application.ban
 import com.b1nd.dodamdodam.core.common.data.Response
 import com.b1nd.dodamdodam.core.security.passport.holder.PassportHolder
 import com.b1nd.dodamdodam.core.security.passport.requireUserId
+import com.b1nd.dodamdodam.grpc.user.UserResponse
 import com.b1nd.dodamdodam.nightstudy.application.ban.data.request.BanUserRequest
 import com.b1nd.dodamdodam.nightstudy.application.ban.data.response.BannedUserResponse
+import com.b1nd.dodamdodam.nightstudy.application.ban.data.response.DormitoryManagerBannedUserResponse
+import com.b1nd.dodamdodam.nightstudy.application.ban.data.toDormitoryManagerResponseList
 import com.b1nd.dodamdodam.nightstudy.application.ban.data.toEntity
 import com.b1nd.dodamdodam.nightstudy.application.ban.data.toResponse
-import com.b1nd.dodamdodam.nightstudy.application.ban.data.toResponseList
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.service.NightStudyBannedService
+import com.b1nd.dodamdodam.nightstudy.infrastructure.user.client.UserQueryClient
+import kotlinx.coroutines.runBlocking
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
@@ -17,6 +21,7 @@ import java.util.UUID
 @Transactional(rollbackFor = [Exception::class])
 class BanUseCase(
     private val nightStudyBannedService: NightStudyBannedService,
+    private val userQueryClient: UserQueryClient,
 ) {
 
     fun ban(request: BanUserRequest): Response<Any> {
@@ -24,13 +29,17 @@ class BanUseCase(
         return Response.created("심야 자습 정지 처리가 완료됐어요.")
     }
 
-    fun getAll(): Response<List<BannedUserResponse>> {
-        val bans = nightStudyBannedService.getAll().toResponseList()
-        return Response.ok("심야 자습 정지 목록을 조회했어요.", bans)
+    @Transactional(readOnly = true)
+    fun getAll(): Response<List<DormitoryManagerBannedUserResponse>> {
+        val bans = nightStudyBannedService.getAll()
+        val userIds = bans.map { it.userId.toString() }.distinct()
+        val usersMap = fetchUsersMap(userIds)
+
+        return Response.ok("심야 자습 정지 목록을 조회했어요.", bans.toDormitoryManagerResponseList(usersMap))
     }
 
     @Transactional(readOnly = true)
-    fun getMyBan(): Response<BannedUserResponse?> {
+    fun getMyBan(): Response<BannedUserResponse> {
         val userId = PassportHolder.current().requireUserId()
         val ban = nightStudyBannedService.findByUserId(userId)?.toResponse()
         return Response.ok("내 심야 자습 정지 정보를 조회했어요.", ban)
@@ -39,5 +48,12 @@ class BanUseCase(
     fun unban(userId: UUID): Response<Any> {
         nightStudyBannedService.unban(userId)
         return Response.ok("심야 자습 정지를 해제했어요.")
+    }
+
+    private fun fetchUsersMap(userIds: List<String>): Map<String, UserResponse> {
+        return if (userIds.isNotEmpty()) {
+            runBlocking { userQueryClient.getUsers(userIds) }
+                .usersList.associateBy { it.publicId }
+        } else emptyMap()
     }
 }

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/ban/data/BanMapper.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/ban/data/BanMapper.kt
@@ -1,7 +1,9 @@
 package com.b1nd.dodamdodam.nightstudy.application.ban.data
 
+import com.b1nd.dodamdodam.grpc.user.UserResponse
 import com.b1nd.dodamdodam.nightstudy.application.ban.data.request.BanUserRequest
 import com.b1nd.dodamdodam.nightstudy.application.ban.data.response.BannedUserResponse
+import com.b1nd.dodamdodam.nightstudy.application.ban.data.response.DormitoryManagerBannedUserResponse
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.entity.NightStudyBannedEntity
 
 fun BanUserRequest.toEntity() = NightStudyBannedEntity(
@@ -18,3 +20,25 @@ fun NightStudyBannedEntity.toResponse() = BannedUserResponse(
 )
 
 fun List<NightStudyBannedEntity>.toResponseList() = map { it.toResponse() }
+
+fun List<NightStudyBannedEntity>.toDormitoryManagerResponseList(
+    usersMap: Map<String, UserResponse>,
+): List<DormitoryManagerBannedUserResponse> = mapNotNull { ban ->
+    usersMap[ban.userId.toString()]?.let { user ->
+        DormitoryManagerBannedUserResponse(
+            userId = ban.userId,
+            reason = ban.reason,
+            name = user.name,
+            student = user.student?.let {
+                DormitoryManagerBannedUserResponse.StudentInfo(
+                    grade = it.grade,
+                    room = it.room,
+                    number = it.number,
+                )
+            } ?: error("could not find user"),
+            phone = user.phone.orEmpty(),
+            endAt = ban.endAt,
+            createdAt = ban.createdAt!!,
+            )
+    }
+}

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/ban/data/response/DormitoryManagerBannedUserResponse.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/ban/data/response/DormitoryManagerBannedUserResponse.kt
@@ -1,0 +1,25 @@
+package com.b1nd.dodamdodam.nightstudy.application.ban.data.response
+
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+data class DormitoryManagerBannedUserResponse(
+    val userId: UUID,
+    val reason: String,
+    val name: String,
+    val student: StudentInfo,
+    val phone: String,
+    val endAt: LocalDate,
+    val createdAt: LocalDateTime,
+) {
+    data class StudentInfo(
+        val grade: Int,
+        val room: Int,
+        val number: Int,
+    )
+
+    companion object {
+
+    }
+}

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/data/response/NightStudyRejectionHistoryResponse.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/data/response/NightStudyRejectionHistoryResponse.kt
@@ -1,0 +1,24 @@
+package com.b1nd.dodamdodam.nightstudy.application.nightstudy.data.response
+
+import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.entity.NightStudyEntity
+import java.time.LocalDate
+
+data class NightStudyRejectionHistoryResponse(
+    val description: String,
+    val rejectionReason: String,
+    val stratAt: LocalDate,
+    val endAt: LocalDate
+) {
+    companion object {
+        fun of(entity: NightStudyEntity): NightStudyRejectionHistoryResponse =
+            NightStudyRejectionHistoryResponse(
+                description = entity.description,
+                rejectionReason = entity.rejectionReason ?: "",
+                stratAt = entity.startAt,
+                endAt = entity.endAt,
+            )
+
+        fun fromList(entities: List<NightStudyEntity>): List<NightStudyRejectionHistoryResponse> =
+            entities.map(::of)
+    }
+}

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/presentation/ban/BanController.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/presentation/ban/BanController.kt
@@ -6,6 +6,7 @@ import com.b1nd.dodamdodam.core.security.passport.enumerations.RoleType
 import com.b1nd.dodamdodam.nightstudy.application.ban.BanUseCase
 import com.b1nd.dodamdodam.nightstudy.application.ban.data.request.BanUserRequest
 import com.b1nd.dodamdodam.nightstudy.application.ban.data.response.BannedUserResponse
+import com.b1nd.dodamdodam.nightstudy.application.ban.data.response.DormitoryManagerBannedUserResponse
 import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.*
 import java.util.UUID
@@ -23,12 +24,12 @@ class BanController(
 
     @UserAccess(roles = [RoleType.DORMITORY_MANAGER])
     @GetMapping
-    fun getAll(): Response<List<BannedUserResponse>> =
+    fun getAll(): Response<List<DormitoryManagerBannedUserResponse>> =
         banUseCase.getAll()
 
     @UserAccess(roles = [RoleType.STUDENT])
     @GetMapping("/my")
-    fun getMyBan(): Response<BannedUserResponse?> =
+    fun getMyBan(): Response<BannedUserResponse> =
         banUseCase.getMyBan()
 
     @UserAccess(roles = [RoleType.DORMITORY_MANAGER])


### PR DESCRIPTION
## 변경 내용
  `/nightstudy/bans` 응답에 학생정보(이름, 학번, 휴대폰)를 함께 내려주도록 수정했습니다.
  - `DormitoryManagerBannedUserResponse`에 `name`, `phone`, `StudentInfo(grade, room, number)` 추가
  - `StudentInfo`의 `grade` / `room` / `number`를 nullable로 변경하여 학생 정보가 없는 케이스에서도 명단 조회가 실패하지 않도록 처리


  ## 관련 이슈
  - Resolves #156 


  ## 테스트 방법
  - [ ] 단위 테스트 추가/수정
  - [ ] 통합 테스트 완료
  - [x] 수동 테스트 완료

  자치위원 계정으로 로그인 → `GET /nightstudy/bans` 호출 → 응답에 `name`, `student.grade/room/number`, `phone`이 포함되는지 확인

  ## 체크리스트
  - [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
  - [x] 자체 코드 리뷰를 완료했습니다
  - [ ] 변경 사항에 대한 테스트를 추가했습니다
  - [ ] 문서를 업데이트했습니다 (필요한 경우)
  - [x] Breaking Changes가 없습니다


  ## 기타 사항