### PR TITLE
Feature/#166 nightstudy student number sort

### DIFF
--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/NightStudyUseCase.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/NightStudyUseCase.kt
@@ -36,7 +36,7 @@ import java.util.UUID
 
 @Component
 @Transactional(rollbackFor = [Exception::class])
-class NightStudyUseCase (
+class NightStudyUseCase(
     private val nightStudyService: NightStudyService,
     private val projectRoomService: ProjectRoomService,
     private val userQueryClient: UserQueryClient,
@@ -85,18 +85,26 @@ class NightStudyUseCase (
                 .ifEmpty { return Response.ok("전체 심야자습 신청 목록을 조회했어요.", InfinityScrollPageResponse(emptyList(), false)) }
         }
 
-        val nightStudiesPage = nightStudyService.searchByType(type, userIds, status, pageable)
-
-        val nightStudiesWithMembers = getNightStudiesWithMembersAndLeaders(nightStudiesPage.content)
+        val allNightStudies = nightStudyService.searchByType(type, userIds, status)
+        val nightStudiesWithMembers = getNightStudiesWithMembersAndLeaders(allNightStudies)
         val usersMap = fetchUsersMap(nightStudiesWithMembers)
-        val responses = nightStudiesWithMembers.toNightStudyApplicationResponses(usersMap)
+
+        val sorted = nightStudiesWithMembers.sortedWith(compareBy(
+            { usersMap[it.leaderId?.toString()]?.student?.grade ?: Int.MAX_VALUE },
+            { usersMap[it.leaderId?.toString()]?.student?.room ?: Int.MAX_VALUE },
+            { usersMap[it.leaderId?.toString()]?.student?.number ?: Int.MAX_VALUE }
+        ))
+
+        val offset = pageable.offset.toInt()
+        val pageSize = pageable.pageSize
+        val sliced = sorted.drop(offset).take(pageSize)
+        val hasNext = offset + pageSize < sorted.size
+
+        val responses = sliced.toNightStudyApplicationResponses(usersMap)
 
         return Response.ok(
             "전체 심야자습 신청 목록을 조회했어요.",
-            InfinityScrollPageResponse(
-                content = responses,
-                hasNext = nightStudiesPage.hasNext()
-            )
+            InfinityScrollPageResponse(content = responses, hasNext = hasNext)
         )
     }
 
@@ -200,11 +208,10 @@ class NightStudyUseCase (
 
     private fun validateApplicationAvailability(stratAt: LocalDate) {
         val now = LocalDateTime.now()
-        val deadline = LocalDate.now().atTime(20,30)
+        val deadline = LocalDate.now().atTime(20, 30)
         if (now.isAfter(deadline))
             throw BasicException(NightStudyExceptionCode.NOT_APPLICATION_TIME)
         if (stratAt.isBefore(now.toLocalDate()))
             throw BasicException(NightStudyExceptionCode.INVALID_START_AT)
     }
 }
-

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepository.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepository.kt
@@ -12,8 +12,8 @@ interface NightStudyQueryRepository {
     fun findByPublicId(publicId: UUID): NightStudyEntity?
     fun findAllByUserIdAndType(userId: UUID, type: NightStudyType, pageable: Pageable): Page<NightStudyEntity>
     fun findAllByUserIdAndType(userId: UUID, type: NightStudyType): List<NightStudyEntity>
-    fun findAllByTypeAndStatus(type: NightStudyType, status: NightStudyStatusType?, pageable: Pageable): Page<NightStudyEntity>
-    fun findAllByTypeAndUserIdsAndStatus(type: NightStudyType, userIds: List<UUID>, status: NightStudyStatusType?, pageable: Pageable): Page<NightStudyEntity>
+    fun findAllByTypeAndStatus(type: NightStudyType, status: NightStudyStatusType?): List<NightStudyEntity>
+    fun findAllByTypeAndUserIdsAndStatus(type: NightStudyType, userIds: List<UUID>, status: NightStudyStatusType?): List<NightStudyEntity>
     fun countAllowedMembersGroupByTypeAndPeriod(): Map<Pair<NightStudyType, Int>, Int>
     fun existsByPublicIdAndUserId(publicId: UUID, userId: UUID): Boolean
     fun existsByUserIdAndPeriodOverlap(userId: UUID, period: Int, type: NightStudyType, startAt: LocalDate, endAt: LocalDate): Boolean

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepositoryImpl.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepositoryImpl.kt
@@ -64,37 +64,21 @@ class NightStudyQueryRepositoryImpl(
         return PageableExecutionUtils.getPage(content, pageable) { countQuery.fetchOne() ?: 0L }
     }
 
-    override fun findAllByTypeAndStatus(type: NightStudyType, status: NightStudyStatusType?, pageable: Pageable): Page<NightStudyEntity> {
+    override fun findAllByTypeAndStatus(type: NightStudyType, status: NightStudyStatusType?): List<NightStudyEntity> {
         val today = LocalDate.now()
-
-        val content = queryFactory.selectFrom(nightStudyEntity)
+        return queryFactory.selectFrom(nightStudyEntity)
             .where(
                 nightStudyEntity.type.eq(type),
                 nightStudyEntity.endAt.goe(today),
                 status?.let { nightStudyEntity.status.eq(it) },
                 hideByActiveProjectCondition(type)
             )
-            .offset(pageable.offset)
-            .limit(pageable.pageSize.toLong())
             .fetch()
-
-        val countQuery = queryFactory
-            .select(nightStudyEntity.count())
-            .from(nightStudyEntity)
-            .where(
-                nightStudyEntity.type.eq(type),
-                nightStudyEntity.endAt.goe(today),
-                status?.let { nightStudyEntity.status.eq(it) },
-                hideByActiveProjectCondition(type)
-            )
-
-        return PageableExecutionUtils.getPage(content, pageable) { countQuery.fetchOne() ?: 0L }
     }
 
-    override fun findAllByTypeAndUserIdsAndStatus(type: NightStudyType, userIds: List<UUID>, status: NightStudyStatusType?, pageable: Pageable): Page<NightStudyEntity> {
+    override fun findAllByTypeAndUserIdsAndStatus(type: NightStudyType, userIds: List<UUID>, status: NightStudyStatusType?): List<NightStudyEntity> {
         val today = LocalDate.now()
-
-        val content = queryFactory.select(nightStudyEntity)
+        return queryFactory.select(nightStudyEntity)
             .from(nightStudyMemberEntity)
             .join(nightStudyMemberEntity.nightStudy, nightStudyEntity)
             .where(
@@ -105,23 +89,7 @@ class NightStudyQueryRepositoryImpl(
                 hideByActiveProjectCondition(type)
             )
             .distinct()
-            .offset(pageable.offset)
-            .limit(pageable.pageSize.toLong())
             .fetch()
-
-        val countQuery = queryFactory
-            .select(nightStudyEntity.countDistinct())
-            .from(nightStudyMemberEntity)
-            .join(nightStudyMemberEntity.nightStudy, nightStudyEntity)
-            .where(
-                nightStudyEntity.type.eq(type),
-                nightStudyEntity.endAt.goe(today),
-                nightStudyMemberEntity.userId.`in`(userIds),
-                status?.let { nightStudyEntity.status.eq(it) },
-                hideByActiveProjectCondition(type)
-            )
-
-        return PageableExecutionUtils.getPage(content, pageable) { countQuery.fetchOne() ?: 0L }
     }
 
     override fun countAllowedMembersGroupByTypeAndPeriod(): Map<Pair<NightStudyType, Int>, Int> {

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyService.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyService.kt
@@ -65,11 +65,11 @@ class NightStudyService(
         return nightStudyQueryRepository.countAllowedMembersGroupByTypeAndPeriod()
     }
 
-    fun searchByType(type: NightStudyType, userIds: List<UUID>?, status: NightStudyStatusType?, pageable: Pageable): Page<NightStudyEntity> {
+    fun searchByType(type: NightStudyType, userIds: List<UUID>?, status: NightStudyStatusType?): List<NightStudyEntity> {
         return if (userIds != null) {
-            nightStudyQueryRepository.findAllByTypeAndUserIdsAndStatus(type, userIds, status, pageable)
+            nightStudyQueryRepository.findAllByTypeAndUserIdsAndStatus(type, userIds, status)
         } else {
-            nightStudyQueryRepository.findAllByTypeAndStatus(type, status, pageable)
+            nightStudyQueryRepository.findAllByTypeAndStatus(type, status)
         }
     }
 


### PR DESCRIPTION
## 변경 내용
심자 신청 인원 목록 조회 API에 학번 순(오름차순) 정렬 적용

- `NightStudyQueryRepository`: `findAllByTypeAndStatus`, `findAllByTypeAndUserIdsAndStatus` 메서드의
`Pageable` 파라미터 제거, 반환 타입 `Page` → `List` 변경
- `NightStudyQueryRepositoryImpl`: 위 메서드 구현체에서 DB 페이지네이션 제거
- `NightStudyService`: `searchByType` 메서드 시그니처 `List` 반환으로 변경
- `NightStudyUseCase`: 전체 데이터 조회 후 leader의 학번(grade → room → number) 기준 메모리 정렬, 이후 메모리 페이지네이션 적용

## 관련 이슈
- Resolves #166

## 테스트 방법
- [x] 수동 테스트 완료

## 스크린샷 (UI 변경 시)
해당 없음

## 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 완료했습니다
- [x] Breaking Changes가 없습니다

## 기타 사항
학번 정보가 user 서비스에 있어 DB 레벨 정렬이 불가능한 구조로, 전체 데이터를 메모리에서 정렬 후 페이지네이션하는 방식으로 구현했습니다.
학교 단위 활성 심자 신청 건수 기준으로 성능상 문제없다고 판단했습니다.