### PR TITLE
feat: UUID v7 기반 publicId 생성 적용

### DIFF
--- a/core/core-common/src/main/kotlin/com/b1nd/dodamdodam/core/common/uuid/UuidV7.kt
+++ b/core/core-common/src/main/kotlin/com/b1nd/dodamdodam/core/common/uuid/UuidV7.kt
@@ -1,0 +1,46 @@
+package com.b1nd.dodamdodam.core.common.uuid
+
+import java.security.SecureRandom
+import java.util.UUID
+
+object UuidV7 {
+    private const val VERSION: Long = 0x7
+    private const val VARIANT: Long = 0x2
+    private const val MAX_SEQUENCE: Int = 0xFFF
+    private const val TIMESTAMP_MASK: Long = 0xFFFFFFFFFFFFL
+    private const val RANDOM_BITS_MASK: Long = 0x3FFFFFFFFFFFFFFFL
+
+    private val random = SecureRandom()
+
+    private var lastTimestamp = -1L
+    private var sequence = 0
+
+    @Synchronized
+    fun generate(): UUID {
+        var timestamp = System.currentTimeMillis()
+
+        if (timestamp > lastTimestamp) {
+            lastTimestamp = timestamp
+            sequence = random.nextInt(MAX_SEQUENCE + 1)
+        } else {
+            if (sequence == MAX_SEQUENCE) {
+                do {
+                    timestamp = System.currentTimeMillis()
+                } while (timestamp <= lastTimestamp)
+                lastTimestamp = timestamp
+                sequence = random.nextInt(MAX_SEQUENCE + 1)
+            } else {
+                sequence += 1
+            }
+        }
+
+        val mostSignificantBits =
+            ((lastTimestamp and TIMESTAMP_MASK) shl 16) or
+                (VERSION shl 12) or
+                sequence.toLong()
+        val leastSignificantBits =
+            (VARIANT shl 62) or (random.nextLong() and RANDOM_BITS_MASK)
+
+        return UUID(mostSignificantBits, leastSignificantBits)
+    }
+}

--- a/core/core-common/src/test/kotlin/com/b1nd/dodamdodam/core/common/uuid/UuidV7Test.kt
+++ b/core/core-common/src/test/kotlin/com/b1nd/dodamdodam/core/common/uuid/UuidV7Test.kt
@@ -1,0 +1,21 @@
+package com.b1nd.dodamdodam.core.common.uuid
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class UuidV7Test {
+    @Test
+    fun `generate uuid v7`() {
+        val uuid = UuidV7.generate()
+
+        assertThat(uuid.version()).isEqualTo(7)
+        assertThat(uuid.variant()).isEqualTo(2)
+    }
+
+    @Test
+    fun `generate time ordered uuid`() {
+        val uuids = List(1_000) { UuidV7.generate().toString() }
+
+        assertThat(uuids).isEqualTo(uuids.sorted())
+    }
+}

--- a/services/service-inapp/src/main/kotlin/com/b1nd/dodamdodam/inapp/domain/app/entity/AppEntity.kt
+++ b/services/service-inapp/src/main/kotlin/com/b1nd/dodamdodam/inapp/domain/app/entity/AppEntity.kt
@@ -1,5 +1,6 @@
 package com.b1nd.dodamdodam.inapp.domain.app.entity
 
+import com.b1nd.dodamdodam.core.common.uuid.UuidV7
 import com.b1nd.dodamdodam.inapp.domain.app.enumeration.AppStatusType
 import com.b1nd.dodamdodam.inapp.domain.team.entity.TeamEntity
 import jakarta.persistence.Column
@@ -46,7 +47,7 @@ class AppEntity(
 
     @PrePersist
     fun generatePublicId() {
-        publicId = UUID.randomUUID()
+        publicId = UuidV7.generate()
     }
 
     fun update(

--- a/services/service-inapp/src/main/kotlin/com/b1nd/dodamdodam/inapp/domain/app/entity/AppReleaseEntity.kt
+++ b/services/service-inapp/src/main/kotlin/com/b1nd/dodamdodam/inapp/domain/app/entity/AppReleaseEntity.kt
@@ -1,5 +1,6 @@
 package com.b1nd.dodamdodam.inapp.domain.app.entity
 
+import com.b1nd.dodamdodam.core.common.uuid.UuidV7
 import com.b1nd.dodamdodam.core.jpa.entity.BaseTimeEntity
 import com.b1nd.dodamdodam.inapp.domain.app.enumeration.AppStatusType
 import jakarta.persistence.Column
@@ -45,7 +46,7 @@ class AppReleaseEntity(
 
     @PrePersist
     fun generatePublicId() {
-        publicId = UUID.randomUUID()
+        publicId = UuidV7.generate()
     }
 
     fun updateStatus(status: AppStatusType, denyResult: String?, updatedUser: UUID) {

--- a/services/service-inapp/src/main/kotlin/com/b1nd/dodamdodam/inapp/domain/team/entity/TeamEntity.kt
+++ b/services/service-inapp/src/main/kotlin/com/b1nd/dodamdodam/inapp/domain/team/entity/TeamEntity.kt
@@ -1,5 +1,6 @@
 package com.b1nd.dodamdodam.inapp.domain.team.entity
 
+import com.b1nd.dodamdodam.core.common.uuid.UuidV7
 import com.b1nd.dodamdodam.core.jpa.entity.BaseTimeEntity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
@@ -29,7 +30,7 @@ class TeamEntity(
 
     @PrePersist
     fun generatePublicId() {
-        publicId = UUID.randomUUID()
+        publicId = UuidV7.generate()
     }
 
     fun update(name: String?, description: String?, iconUrl: String?, githubUrl: String?) {

--- a/services/service-neis/src/main/kotlin/com/b1nd/dodamdodam/neis/domain/schedule/entity/ScheduleEntity.kt
+++ b/services/service-neis/src/main/kotlin/com/b1nd/dodamdodam/neis/domain/schedule/entity/ScheduleEntity.kt
@@ -1,5 +1,6 @@
 package com.b1nd.dodamdodam.neis.domain.schedule.entity
 
+import com.b1nd.dodamdodam.core.common.uuid.UuidV7
 import com.b1nd.dodamdodam.core.jpa.entity.BaseTimeEntity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
@@ -33,7 +34,7 @@ class ScheduleEntity(
 
     @PrePersist
     fun generatePublicId() {
-        publicId = UUID.randomUUID()
+        publicId = UuidV7.generate()
     }
 
     fun update(title: String, startAt: LocalDate, endAt: LocalDate) {

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/entity/NightStudyEntity.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/entity/NightStudyEntity.kt
@@ -1,5 +1,6 @@
 package com.b1nd.dodamdodam.nightstudy.domain.nightstudy.entity
 
+import com.b1nd.dodamdodam.core.common.uuid.UuidV7
 import com.b1nd.dodamdodam.core.jpa.entity.BaseTimeEntity
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.enumeration.NightStudyStatusType
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.enumeration.NightStudyType
@@ -62,7 +63,7 @@ class NightStudyEntity (
 
     @PrePersist
     fun generatePublicId() {
-        publicId = UUID.randomUUID()
+        publicId = UuidV7.generate()
     }
 
     fun allow() {

--- a/services/service-out-sleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/domain/outsleeping/entity/OutSleepingEntity.kt
+++ b/services/service-out-sleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/domain/outsleeping/entity/OutSleepingEntity.kt
@@ -1,5 +1,6 @@
 package com.b1nd.dodamdodam.outsleeping.domain.outsleeping.entity
 
+import com.b1nd.dodamdodam.core.common.uuid.UuidV7
 import com.b1nd.dodamdodam.core.jpa.entity.BaseTimeEntity
 import com.b1nd.dodamdodam.outsleeping.domain.outsleeping.enumeration.OutSleepingStatus
 import com.b1nd.dodamdodam.outsleeping.domain.outsleeping.exception.OutSleepingAlreadyProcessedException
@@ -51,7 +52,7 @@ class OutSleepingEntity(
 
     @PrePersist
     fun generatePublicId() {
-        publicId = UUID.randomUUID()
+        publicId = UuidV7.generate()
     }
 
     fun allow() {

--- a/services/service-user/src/main/kotlin/com/b1nd/dodamdodam/user/domain/user/entity/UserEntity.kt
+++ b/services/service-user/src/main/kotlin/com/b1nd/dodamdodam/user/domain/user/entity/UserEntity.kt
@@ -1,5 +1,6 @@
 package com.b1nd.dodamdodam.user.domain.user.entity
 
+import com.b1nd.dodamdodam.core.common.uuid.UuidV7
 import com.b1nd.dodamdodam.core.jpa.entity.BaseTimeEntity
 import com.b1nd.dodamdodam.user.domain.user.enumeration.StatusType
 import jakarta.persistence.Column
@@ -43,7 +44,7 @@ class UserEntity (
 
     @PrePersist
     fun generatePublicId() {
-        publicId = UUID.randomUUID()
+        publicId = UuidV7.generate()
     }
 
     fun updatePassword(newPassword: String) {


### PR DESCRIPTION
## 변경 내용

- UUID v7 생성 유틸을 추가했습니다.
- 주요 엔티티의 `publicId` 생성 방식을 UUID v4에서 UUID v7로 변경했습니다.
- UUID v7의 version/variant 및 생성 순서 정렬을 검증하는 테스트를 추가했습니다.

## 관련 이슈

- Resolves #127

## 테스트 방법

- [x] 단위 테스트 추가/수정
- [x] 통합 테스트 완료
- [x] 수동 테스트 완료

검증한 명령:
- `./gradlew :core:core-common:test`
- `./gradlew :services:service-user:compileKotlin :services:service-out-sleeping:compileKotlin :services:service-neis:compileKotlin :services:service-nightstudy:compileKotlin :services:service-inapp:compileKotlin`

수동 테스트:
- Postman으로 `POST /user/register-student` 요청 후 학생 계정 생성 확인

## 스크린샷 (UI 변경 시)

없음

## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 완료했습니다
- [x] 변경 사항에 대한 테스트를 추가했습니다
- [x] 문서를 업데이트했습니다 (필요한 경우)
- [x] Breaking Changes가 없습니다

## 기타 사항

- 기존 데이터의 UUID는 변경하지 않고, 신규 생성되는 `publicId`부터 UUID v7이 적용됩니다.
- 보안 토큰, 초대코드, 파일명처럼 난수성이 중요한 값은 기존 UUID v4 생성을 유지했습니다.