### PR TITLE
feat: 일반 심자 목록에 프로젝트 심자 인원 여부 추가

### DIFF
--- a/services/service-neis/src/main/kotlin/com/b1nd/dodamdodam/neis/infrastructure/comcigan/ComciganClient.kt
+++ b/services/service-neis/src/main/kotlin/com/b1nd/dodamdodam/neis/infrastructure/comcigan/ComciganClient.kt
@@ -51,7 +51,7 @@ class ComciganClient(
         orgNum = orgDataMatch?.groupValues?.get(1)?.toInt()
             ?: throw IllegalStateException("컴시간 orgNum 추출 실패")
         dayNum = dayDataMatch?.groupValues?.get(1)?.toInt() ?: orgNum
-        thNum = Regex("성명=자료\\.자료(\\d+)").find(html)?.groupValues?.get(1)?.toInt()
+        thNum = Regex("자료\\.자료(\\d+)\\[th]").find(html)?.groupValues?.get(1)?.toInt()
             ?: throw IllegalStateException("컴시간 thNum 추출 실패")
         sbNum = Regex("자료\\.자료(\\d+)\\[sb]").find(html)?.groupValues?.get(1)?.toInt()
             ?: throw IllegalStateException("컴시간 sbNum 추출 실패")

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/NightStudyUseCase.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/NightStudyUseCase.kt
@@ -88,6 +88,7 @@ class NightStudyUseCase(
         val allNightStudies = nightStudyService.searchByType(type, userIds, status)
         val nightStudiesWithMembers = getNightStudiesWithMembersAndLeaders(allNightStudies)
         val usersMap = fetchUsersMap(nightStudiesWithMembers)
+        val projectMemberNightStudyIds = nightStudyService.getProjectMemberNightStudyIds(allNightStudies)
 
         val sorted = nightStudiesWithMembers.sortedWith(compareBy(
             { usersMap[it.leaderId?.toString()]?.student?.grade ?: Int.MAX_VALUE },
@@ -100,7 +101,7 @@ class NightStudyUseCase(
         val sliced = sorted.drop(offset).take(pageSize)
         val hasNext = offset + pageSize < sorted.size
 
-        val responses = sliced.toNightStudyApplicationResponses(usersMap)
+        val responses = sliced.toNightStudyApplicationResponses(usersMap, projectMemberNightStudyIds)
 
         return Response.ok(
             "전체 심야자습 신청 목록을 조회했어요.",

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/data/NightStudyMapper.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/data/NightStudyMapper.kt
@@ -83,7 +83,8 @@ fun UserResponse.toOpenApiUserInfoResponse() = NightStudyApplicantResponse(
 
 fun NightStudyEntity.toOpenApiNightStudyResponse(
     leader: NightStudyApplicantResponse,
-    members: List<NightStudyApplicantResponse>
+    members: List<NightStudyApplicantResponse>,
+    isProjectNightStudyMember: Boolean = false,
 ) = NightStudyApplicationResponse(
     id = publicId!!,
     name = name,
@@ -99,17 +100,20 @@ fun NightStudyEntity.toOpenApiNightStudyResponse(
     rejectionReason = rejectionReason,
     type = type,
     room = room?.let { NightStudyApplicationResponse.RoomInfo(id = it.id!!, name = it.name) },
+    isProjectNightStudyMember = isProjectNightStudyMember,
 )
 
 fun List<NightStudyWithMembersCommand>.toNightStudyApplicationResponses(
-    usersMap: Map<String, NightStudyApplicantResponse>
+    usersMap: Map<String, NightStudyApplicantResponse>,
+    projectMemberNightStudyIds: Set<Long> = emptySet(),
 ): List<NightStudyApplicationResponse> {
     return mapNotNull { command ->
         command.leaderId?.let { leaderId ->
             usersMap[leaderId.toString()]?.let { leader ->
                 command.nightStudy.toOpenApiNightStudyResponse(
                     leader = leader,
-                    members = command.memberIds.mapNotNull { memberId -> usersMap[memberId.toString()] }
+                    members = command.memberIds.mapNotNull { memberId -> usersMap[memberId.toString()] },
+                    isProjectNightStudyMember = command.nightStudy.id in projectMemberNightStudyIds,
                 )
             }
         }

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/data/response/NightStudyApplicationResponse.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/data/response/NightStudyApplicationResponse.kt
@@ -20,6 +20,7 @@ data class NightStudyApplicationResponse(
     val rejectionReason: String?,
     val type: NightStudyType,
     val room: RoomInfo?,
+    val isProjectNightStudyMember: Boolean,
 ) {
     data class RoomInfo(
         val id: Long,

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepository.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepository.kt
@@ -19,4 +19,5 @@ interface NightStudyQueryRepository {
     fun existsByUserIdAndPeriodOverlap(userId: UUID, period: Int, type: NightStudyType, startAt: LocalDate, endAt: LocalDate): Boolean
     fun existsByRoomAndPeriodOverlap(roomId: Long, period: Int, startAt: LocalDate, endAt: LocalDate, excludeNightStudyId: Long): Boolean
     fun findActivePersonalsByUserIdsAndPeriodOverlap(userIds: List<UUID>, period: Int, startAt: LocalDate, endAt: LocalDate): List<NightStudyEntity>
+    fun findProjectMemberNightStudyIds(nightStudies: List<NightStudyEntity>): Set<Long>
 }

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepositoryImpl.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepositoryImpl.kt
@@ -8,8 +8,6 @@ import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.entity.QNightStudyMember
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.enumeration.NightStudyStatusType
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.enumeration.NightStudyType
 import com.b1nd.dodamdodam.nightstudy.domain.room.entity.QProjectRoomEntity
-import com.querydsl.core.types.dsl.BooleanExpression
-import com.querydsl.jpa.JPAExpressions
 import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
@@ -71,7 +69,6 @@ class NightStudyQueryRepositoryImpl(
                 nightStudyEntity.type.eq(type),
                 nightStudyEntity.endAt.goe(today),
                 status?.let { nightStudyEntity.status.eq(it) },
-                hideByActiveProjectCondition(type)
             )
             .fetch()
     }
@@ -87,7 +84,6 @@ class NightStudyQueryRepositoryImpl(
                 nightStudyEntity.endAt.goe(today),
                 nightStudyMemberEntity.userId.`in`(userIds),
                 status?.let { nightStudyEntity.status.eq(it) },
-                hideByActiveProjectCondition(type)
             )
             .distinct()
             .fetch()
@@ -190,19 +186,23 @@ class NightStudyQueryRepositoryImpl(
             .fetch()
     }
 
-    private fun hideByActiveProjectCondition(type: NightStudyType): BooleanExpression? {
-        if (type != NightStudyType.PERSONAL) return null
+    override fun findProjectMemberNightStudyIds(nightStudies: List<NightStudyEntity>): Set<Long> {
+        val nightStudyIds = nightStudies.mapNotNull { it.id }
+        if (nightStudyIds.isEmpty()) return emptySet()
 
         val project = QNightStudyEntity("project")
         val projectMember = QNightStudyMemberEntity("projectMember")
         val personalMember = QNightStudyMemberEntity("personalMember")
 
-        return JPAExpressions
-            .selectOne()
-            .from(project)
-            .join(projectMember).on(projectMember.nightStudy.eq(project))
+        return queryFactory
+            .select(nightStudyEntity.id)
+            .from(nightStudyEntity)
             .join(personalMember).on(personalMember.nightStudy.eq(nightStudyEntity))
+            .join(projectMember).on(projectMember.userId.eq(personalMember.userId))
+            .join(projectMember.nightStudy, project)
             .where(
+                nightStudyEntity.id.`in`(nightStudyIds),
+                nightStudyEntity.type.eq(NightStudyType.PERSONAL),
                 project.type.eq(NightStudyType.PROJECT),
                 project.status.`in`(NightStudyStatusType.PENDING, NightStudyStatusType.ALLOWED),
                 project.period.eq(nightStudyEntity.period),
@@ -210,6 +210,9 @@ class NightStudyQueryRepositoryImpl(
                 project.endAt.goe(nightStudyEntity.startAt),
                 projectMember.userId.eq(personalMember.userId)
             )
-            .notExists()
+            .distinct()
+            .fetch()
+            .filterNotNull()
+            .toSet()
     }
 }

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyService.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyService.kt
@@ -73,6 +73,10 @@ class NightStudyService(
         }
     }
 
+    fun getProjectMemberNightStudyIds(nightStudies: List<NightStudyEntity>): Set<Long> {
+        return nightStudyQueryRepository.findProjectMemberNightStudyIds(nightStudies)
+    }
+
     fun getByPublicId(publicId: UUID): NightStudyEntity {
         return nightStudyQueryRepository.findByPublicId(publicId) ?: throw NightStudyNotFoundException()
     }

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/infrastructure/swagger/SwaggerRedirectController.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/infrastructure/swagger/SwaggerRedirectController.kt
@@ -1,0 +1,11 @@
+package com.b1nd.dodamdodam.nightstudy.infrastructure.swagger
+
+import org.springframework.stereotype.Controller
+import org.springframework.web.bind.annotation.GetMapping
+
+@Controller
+class SwaggerRedirectController {
+
+    @GetMapping("/swagger-ui", "/swagger-ui/")
+    fun redirectToSwaggerUi(): String = "redirect:/swagger-ui/index.html"
+}


### PR DESCRIPTION
## 변경 내용

- 관리자 일반 심자 목록 응답에 `isProjectNightStudyMember` 필드를 추가했습니다.
- 프로젝트 심자와 기간/교시가 겹치는 일반 심자 신청자를 목록에서 숨기지 않고, 해당 필드로 구분할 수 있도록 변경했습니다.
- `/nightstudy/swagger-ui`, `/nightstudy/swagger-ui/` 접근 시 500이 발생하던 문제를 리다이렉트로 함께 수정했습니다.

## 관련 이슈

- Resolves #190

## 테스트 방법

- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 완료
- [x] 수동 테스트 완료

검증한 명령:
- `./gradlew :services:service-nightstudy:compileKotlin`

## 스크린샷 (UI 변경 시)

해당 없음

## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 완료했습니다
- [ ] 변경 사항에 대한 테스트를 추가했습니다
- [x] 문서를 업데이트했습니다 (필요한 경우)
- [x] Breaking Changes가 없습니다

## 기타 사항

- Swagger UI 경로 수정은 별도 커밋으로 분리했습니다.