### PR TITLE
revert: 컴시간 주차 계산 로직 제거 및 시간표 조회 0주차 고정

### DIFF
--- a/services/service-neis/src/main/kotlin/com/b1nd/dodamdodam/neis/infrastructure/comcigan/ComciganClient.kt
+++ b/services/service-neis/src/main/kotlin/com/b1nd/dodamdodam/neis/infrastructure/comcigan/ComciganClient.kt
@@ -77,9 +77,7 @@ class ComciganClient(
     }
 
     fun fetchWeeklyTimeTables(mondayDate: LocalDate): List<ParsedTimeTable> {
-        val base = fetchTimetable()
-        val r = resoloveWeek(base, mondayDate)
-        val json = if (r==0) base else fetchTimetable(r)
+        val json = fetchTimetable()
         val subjects = json["자료$sbNum"]
         val teachers = json["자료$thNum"]
         val timetableData = json["자료$dayNum"]
@@ -112,9 +110,7 @@ class ComciganClient(
         if (dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY) return emptyList()
 
         val dayIdx = dayOfWeek.value
-        val base = fetchTimetable()
-        val r = resoloveWeek(base, date)
-        val json = if (r == 0) base else fetchTimetable(r)
+        val json = fetchTimetable()
         val subjects = json["자료$sbNum"]
         val teachers = json["자료$thNum"]
         val timetableData = json["자료$dayNum"]
@@ -167,8 +163,8 @@ class ComciganClient(
         }
     }
 
-    private fun fetchTimetable(r: Int = 0): JsonNode {
-        val param = "$prefix${schoolCode}_${r}_1"
+    private fun fetchTimetable(): JsonNode {
+        val param = "$prefix${schoolCode}_0_1"
         val encoded = Base64.getEncoder().encodeToString(param.toByteArray(Charsets.UTF_8))
         val body = fetchAsUtf8("$baseUrl?$encoded")
         return objectMapper.readTree(body.replace("\u0000", ""))


### PR DESCRIPTION
## 변경 내용
주차 계산 로직을 제거했습니다.
시간표 조회를 0주차로 고정했습니다.
<!-- 이 PR에서 무엇을 변경했는지 간단히 요약해주세요 -->


## 관련 이슈

<!-- 관련된 이슈를 연결해주세요 -->
- Resolves #198


## 테스트 방법

<!-- 어떻게 테스트했는지 설명해주세요 -->
- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 완료
- [x] 수동 테스트 완료


## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [ ] 자체 코드 리뷰를 완료했습니다
- [ ] 변경 사항에 대한 테스트를 추가했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [ ] Breaking Changes가 없습니다


## 기타 사항

<!-- 리뷰어가 특별히 주의해서 봐야 할 부분이나 추가 설명 -->