### PR TITLE
feat: 층계 심자 인원 카운트 api 추가

### DIFF
--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/NightStudyUseCase.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/NightStudyUseCase.kt
@@ -22,8 +22,10 @@ import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.enumeration.NightStudyTy
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.service.NightStudyService
 import com.b1nd.dodamdodam.nightstudy.domain.room.service.ProjectRoomService
 import com.b1nd.dodamdodam.nightstudy.infrastructure.user.client.UserQueryClient
+import com.b1nd.dodamdodam.grpc.user.UserResponse
 import com.b1nd.dodamdodam.core.common.data.InfinityScrollPageResponse
 import com.b1nd.dodamdodam.core.common.exception.BasicException
+import com.b1nd.dodamdodam.nightstudy.application.nightstudy.data.response.NightStudyTotalCountResponse
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.enumeration.NightStudyStatusType
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.exception.NightStudyExceptionCode
 import kotlinx.coroutines.runBlocking
@@ -161,6 +163,42 @@ class NightStudyUseCase(
         nightStudyService.assignRoom(id, room)
         return Response.ok("방 배정이 완료됐어요.")
     }
+
+    fun countTotalMembers(): Response<NightStudyTotalCountResponse> {
+        val nightStudys = nightStudyService.getAllAllowed()
+
+        val membersByNightStudy = nightStudyService.getMembersByNightStudies(nightStudys)
+        val userIds = membersByNightStudy.values.flatten()
+            .map { it.toString() }
+            .distinct()
+
+        val userById = runBlocking { userQueryClient.getUsers(userIds) }.usersList
+            .associateBy { it.publicId }
+
+        val counts = nightStudys.flatMap { nightStudy ->
+            val memberIds = membersByNightStudy[nightStudy.id] ?: emptyList()
+
+            memberIds.map { memberId ->
+                val user = userById[memberId.toString()]
+                Triple(
+                    resolveFloor(nightStudy, user),
+                    nightStudy.type,
+                    nightStudy.period,
+                )
+            }
+        }.groupingBy { it }.eachCount()
+
+        return Response.ok("심자 층별 인원수를 조회했어요.", NightStudyTotalCountResponse.of(counts))
+    }
+
+    private fun resolveFloor(nightStudy: NightStudyEntity, user: UserResponse?): Int =
+        if (nightStudy.type == NightStudyType.PROJECT) {
+            if (nightStudy.room?.name == "LAB13") 3 else 2
+        } else {
+            val grade = user?.student?.grade
+            val classNo = user?.student?.room
+            if (grade == 2 || (grade == 1 && classNo == 4)) 3 else 2
+        }
 
     fun unassignRoom(id: UUID): Response<Any> {
         nightStudyService.unassignRoom(id)

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/data/response/NightStudyTotalCountResponse.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/data/response/NightStudyTotalCountResponse.kt
@@ -1,0 +1,52 @@
+package com.b1nd.dodamdodam.nightstudy.application.nightstudy.data.response
+
+import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.enumeration.NightStudyType
+
+data class NightStudyTotalCountResponse(
+    val floors: List<FloorCount>,
+    val total: PeriodCount,
+) {
+    data class FloorCount(
+        val floor: Int,
+        val count: PeriodCount,
+    )
+
+    data class PeriodCount(
+        val period1: TypeCount,
+        val period2: TypeCount,
+    )
+
+    data class TypeCount(
+        val personal: Int,
+        val project: Int,
+    )
+
+    companion object {
+        fun of(count: Map<Triple<Int, NightStudyType, Int>, Int>): NightStudyTotalCountResponse {
+            fun typeCount(floor: Int, period: Int) = TypeCount(
+                personal = count[Triple(floor, NightStudyType.PERSONAL, period)] ?: 0,
+                project = count[Triple(floor, NightStudyType.PROJECT, period)] ?: 0,
+            )
+            fun periodCount(floor: Int) = PeriodCount(
+                period1 = typeCount(floor,1),
+                period2 = typeCount(floor,2),
+            )
+
+            val floors = listOf(2, 3).map { floor ->
+                FloorCount(floor = floor, count = periodCount(floor))
+            }
+            val total = PeriodCount(
+                period1 = TypeCount(
+                    personal = floors.sumOf { it.count.period1.personal },
+                    project = floors.sumOf { it.count.period1.project },
+                ),
+                period2 = TypeCount(
+                    personal = floors.sumOf { it.count.period2.personal },
+                    project = floors.sumOf { it.count.period2.project },
+                ),
+            )
+
+            return NightStudyTotalCountResponse(floors = floors, total = total)
+        }
+    }
+}

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyRepository.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyRepository.kt
@@ -1,6 +1,10 @@
 package com.b1nd.dodamdodam.nightstudy.domain.nightstudy.repository.nightStudy
 
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.entity.NightStudyEntity
+import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.enumeration.NightStudyStatusType
 import org.springframework.data.jpa.repository.JpaRepository
+import java.util.List
 
-interface NightStudyRepository: JpaRepository<NightStudyEntity, Long>
+interface NightStudyRepository: JpaRepository<NightStudyEntity, Long> {
+    fun findAllByStatus(status: NightStudyStatusType): List<NightStudyEntity>
+}

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyService.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyService.kt
@@ -156,6 +156,10 @@ class NightStudyService(
         getByPublicId(publicId).unassignRoom()
     }
 
+    fun getAllAllowed(): List<NightStudyEntity> {
+        return nightStudyRepository.findAllByStatus(NightStudyStatusType.ALLOWED) as List<NightStudyEntity>
+    }
+
     private fun isBanned(userId: UUID): Boolean {
         return bannedRepository.existsByUserId(userId)
     }

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/presentation/nightstudy/NightStudyController.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/presentation/nightstudy/NightStudyController.kt
@@ -15,6 +15,7 @@ import com.b1nd.dodamdodam.nightstudy.application.nightstudy.data.response.Proje
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.enumeration.NightStudyStatusType
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.enumeration.NightStudyType
 import com.b1nd.dodamdodam.core.common.data.InfinityScrollPageResponse
+import com.b1nd.dodamdodam.nightstudy.application.nightstudy.data.response.NightStudyTotalCountResponse
 import org.springframework.data.domain.Pageable
 import org.springframework.web.bind.annotation.*
 import java.util.UUID
@@ -87,5 +88,10 @@ class NightStudyController(
     @DeleteMapping("/applications/{id}/room")
     fun unassignRoom(@PathVariable id: UUID): Response<Any> =
         nightStudyUseCase.unassignRoom(id)
+
+    @UserAccess(roles = [RoleType.DORMITORY_MANAGER])
+    @GetMapping("/applications/total")
+    fun countTotalMembers(): Response<NightStudyTotalCountResponse> =
+        nightStudyUseCase.countTotalMembers()
 }
 


### PR DESCRIPTION
## 변경 내용
층계 간 심야자습 인원 총원을 알 수 있는 api를 추가했습니다

Response
```json
{
    "status": 200,
    "message": "심자 층별 인원수를 조회했어요.",
    "data": {
        "floors": [
            {
                "floor": 2,
                "count": {
                    "period1": {
                        "personal": 0,
                        "project": 0
                    },
                    "period2": {
                        "personal": 0,
                        "project": 3
                    }
                }
            },
            {
                "floor": 3,
                "count": {
                    "period1": {
                        "personal": 0,
                        "project": 4
                    },
                    "period2": {
                        "personal": 1,
                        "project": 0
                    }
                }
            }
        ],
        "total": {
            "period1": {
                "personal": 0,
                "project": 4
            },
            "period2": {
                "personal": 1,
                "project": 3
            }
        }
    }
}
```


## 관련 이슈

<!-- 관련된 이슈를 연결해주세요 -->
- Resolves #200 


## 테스트 방법

<!-- 어떻게 테스트했는지 설명해주세요 -->
- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 완료
- [x] 수동 테스트 완료


## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 완료했습니다
- [ ] 변경 사항에 대한 테스트를 추가했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [ ] Breaking Changes가 없습니다


## 기타 사항

<!-- 리뷰어가 특별히 주의해서 봐야 할 부분이나 추가 설명 -->