### PR TITLE
fix: 심자 데이터 조회 로직 중 오늘 심자데이터만 return 하도록 수정

### DIFF
--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/data/response/NightStudyTotalCountResponse.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/data/response/NightStudyTotalCountResponse.kt
@@ -23,13 +23,13 @@ data class NightStudyTotalCountResponse(
 
     companion object {
         fun of(count: Map<Triple<Int, NightStudyType, Int>, Int>): NightStudyTotalCountResponse {
-            fun typeCount(floor: Int, period: Int) = TypeCount(
-                personal = count[Triple(floor, NightStudyType.PERSONAL, period)] ?: 0,
-                project = count[Triple(floor, NightStudyType.PROJECT, period)] ?: 0,
+            fun typeCount(floor: Int, vararg periods: Int) = TypeCount(
+                personal = periods.sumOf { count[Triple(floor, NightStudyType.PERSONAL, it)] ?: 0 },
+                project = periods.sumOf { count[Triple(floor, NightStudyType.PROJECT, it)] ?: 0 },
             )
             fun periodCount(floor: Int) = PeriodCount(
-                period1 = typeCount(floor,1),
-                period2 = typeCount(floor,2),
+                period1 = typeCount(floor, 1, 2),
+                period2 = typeCount(floor, 2),
             )
 
             val floors = listOf(2, 3).map { floor ->

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepository.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepository.kt
@@ -24,4 +24,5 @@ interface NightStudyQueryRepository {
     fun findActivePersonalsByUserIdsAndPeriodOverlap(userIds: List<UUID>, period: Int, startAt: LocalDate, endAt: LocalDate): List<NightStudyEntity>
     fun findProjectMemberNightStudyIds(nightStudies: List<NightStudyEntity>): Set<Long>
     fun findAllByTypeAndStartAtLessThanEqualAndEndAtGreaterThanEqual(type: NightStudyType, startAt: LocalDate, endAt: LocalDate): List<NightStudyEntity>
+    fun findAllByStatusAndStartAtLessThanEqualAndEndAtGreaterThanEqual(status: NightStudyStatusType, startAt: LocalDate, endAt: LocalDate): List<NightStudyEntity>
 }

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepositoryImpl.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepositoryImpl.kt
@@ -1,8 +1,8 @@
 package com.b1nd.dodamdodam.nightstudy.domain.nightstudy.repository.nightStudy
 
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.entity.NightStudyEntity
-import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.entity.QNightStudyEntity
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.entity.QNightStudyAttendanceEntity.nightStudyAttendanceEntity
+import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.entity.QNightStudyEntity
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.entity.QNightStudyEntity.nightStudyEntity
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.entity.QNightStudyMemberEntity
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.entity.QNightStudyMemberEntity.nightStudyMemberEntity
@@ -240,6 +240,20 @@ class NightStudyQueryRepositoryImpl(
                 nightStudyEntity.startAt.loe(endAt),
                 nightStudyEntity.endAt.goe(startAt),
                 nightStudyEntity.status.eq(NightStudyStatusType.ALLOWED)
+            )
+            .fetch()
+    }
+
+    override fun findAllByStatusAndStartAtLessThanEqualAndEndAtGreaterThanEqual(
+        status: NightStudyStatusType,
+        startAt: LocalDate,
+        endAt: LocalDate
+    ): List<NightStudyEntity> {
+        return queryFactory.selectFrom(nightStudyEntity)
+            .where(
+                nightStudyEntity.status.eq(status),
+                nightStudyEntity.startAt.loe(startAt),
+                nightStudyEntity.endAt.goe(endAt),
             )
             .fetch()
     }

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyService.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyService.kt
@@ -157,7 +157,9 @@ class NightStudyService(
     }
 
     fun getAllAllowed(): List<NightStudyEntity> {
-        return nightStudyRepository.findAllByStatus(NightStudyStatusType.ALLOWED) as List<NightStudyEntity>
+        return nightStudyQueryRepository.findAllByStatusAndStartAtLessThanEqualAndEndAtGreaterThanEqual(
+            NightStudyStatusType.ALLOWED, LocalDate.now(), LocalDate.now()
+        )
     }
 
     private fun isBanned(userId: UUID): Boolean {


### PR DESCRIPTION
## 변경 내용
심자 데이터 조회 시 날짜를 오늘로 넣어 과거 데이터를 카운트 하지 않게 수정
<!-- 이 PR에서 무엇을 변경했는지 간단히 요약해주세요 -->


## 관련 이슈

<!-- 관련된 이슈를 연결해주세요 -->
- Resolves #207 


## 테스트 방법

<!-- 어떻게 테스트했는지 설명해주세요 -->
- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 완료
- [x] 수동 테스트 완료


## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 완료했습니다
- [ ] 변경 사항에 대한 테스트를 추가했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [ ] Breaking Changes가 없습니다


## 기타 사항

<!-- 리뷰어가 특별히 주의해서 봐야 할 부분이나 추가 설명 -->