### PR TITLE
fix: 심야자습 출석 조회/집계 시 상위 period 신청자를 포함하도록 수정

### DIFF
--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepositoryImpl.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepositoryImpl.kt
@@ -149,7 +149,7 @@ class NightStudyQueryRepositoryImpl(
             .where(
                 nightStudyMemberEntity.userId.eq(userId),
                 nightStudyEntity.status.eq(NightStudyStatusType.ALLOWED),
-                nightStudyEntity.period.eq(period),
+                nightStudyEntity.period.goe(period),
                 nightStudyEntity.startAt.loe(date),
                 nightStudyEntity.endAt.goe(date),
             )
@@ -162,7 +162,7 @@ class NightStudyQueryRepositoryImpl(
             .join(nightStudyMemberEntity.nightStudy, nightStudyEntity)
             .where(
                 nightStudyEntity.status.eq(NightStudyStatusType.ALLOWED),
-                nightStudyEntity.period.eq(period),
+                nightStudyEntity.period.goe(period),
                 nightStudyEntity.startAt.loe(date),
                 nightStudyEntity.endAt.goe(date),
             )


### PR DESCRIPTION
## 변경 내용
심2 신청자는 심1 시간에도 자리에 있으므로 eq를 period.goe로 변경해 심2 신청자의 심1 출석 체크 및 인원 집계가 정상 동작하도록 수정했습니다.
<!-- 이 PR에서 무엇을 변경했는지 간단히 요약해주세요 -->


## 관련 이슈

<!-- 관련된 이슈를 연결해주세요 -->
- Resolves #213 


## 테스트 방법

<!-- 어떻게 테스트했는지 설명해주세요 -->
- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 완료
- [x] 수동 테스트 완료

## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 완료했습니다
- [ ] 변경 사항에 대한 테스트를 추가했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [ ] Breaking Changes가 없습니다


## 기타 사항

<!-- 리뷰어가 특별히 주의해서 봐야 할 부분이나 추가 설명 -->