### PR TITLE
fix: allow owner to deactivate oauth client

### DIFF
--- a/services/service-oauth/src/main/kotlin/com/b1nd/dodamdodam/oauth/application/usecase/OauthClientUseCase.kt
+++ b/services/service-oauth/src/main/kotlin/com/b1nd/dodamdodam/oauth/application/usecase/OauthClientUseCase.kt
@@ -73,9 +73,12 @@ class OauthClientUseCase(
     }
 
     @Transactional
-    suspend fun deactivateClient(clientId: String, clientSecret: String) {
+    suspend fun deactivateClient(clientId: String, clientSecret: String?, ownerPublicId: UUID? = null) {
         val client = clientService.findByClientId(clientId)
-        clientService.verifyClientSecret(client, clientSecret, passwordEncoder)
+        if (client.ownerPublicId != ownerPublicId) {
+            if (clientSecret.isNullOrBlank()) throw OauthException(OauthExceptionCode.INVALID_REQUEST)
+            clientService.verifyClientSecret(client, clientSecret, passwordEncoder)
+        }
         clientService.save(client.copy(isActive = false))
     }
 

--- a/services/service-oauth/src/main/kotlin/com/b1nd/dodamdodam/oauth/presentation/client/ClientController.kt
+++ b/services/service-oauth/src/main/kotlin/com/b1nd/dodamdodam/oauth/presentation/client/ClientController.kt
@@ -63,10 +63,13 @@ class ClientController(
     @DeleteMapping("/{clientId}")
     suspend fun deactivateClient(
         @PathVariable clientId: String,
-        @RequestBody body: Map<String, String>,
+        @RequestHeader("X-User-Passport", required = false) passport: String?,
+        @RequestBody(required = false) body: Map<String, String>?,
     ): Response<Unit> {
-        val secret = body["clientSecret"] ?: throw OauthException(OauthExceptionCode.INVALID_REQUEST)
-        clientUseCase.deactivateClient(clientId, secret)
+        val ownerPublicId = passport
+            ?.takeIf { it.isNotBlank() }
+            ?.let { PassportResolver.extractUserId(it) }
+        clientUseCase.deactivateClient(clientId, body?.get("clientSecret"), ownerPublicId)
         return Response.ok("클라이언트가 비활성화되었어요.")
     }
 


### PR DESCRIPTION
## 변경 내용

- OAuth 클라이언트 삭제 API에서 `clientSecret` 요청 바디를 선택값으로 변경했습니다.
- 로그인된 사용자가 해당 OAuth 클라이언트의 소유자인 경우, `clientSecret` 없이도 비활성화/삭제할 수 있도록 수정했습니다.
- 소유자가 아닌 요청은 기존처럼 `clientSecret` 검증을 거치도록 유지했습니다.

## 관련 이슈

- Resolves #220

## 테스트 방법

- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 완료
- [x] 수동 테스트 완료

`./gradlew :services:service-oauth:compileKotlin --no-daemon`

## 스크린샷 (UI 변경 시)

UI 변경 없음

### Before

없음

### After

없음

## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 완료했습니다
- [ ] 변경 사항에 대한 테스트를 추가했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] Breaking Changes가 없습니다

## 기타 사항

기존 `clientSecret` 기반 삭제 흐름은 유지했습니다.  
다만 웹/클라이언트 환경에서 `DELETE` 요청 body가 누락될 수 있어, 로그인된 소유자 기준 삭제도 허용하도록 보완했습니다.