### PR TITLE
fix: AID 웹뷰 S3 접근 경로 설정 수정

### DIFF
--- a/builds/develop/docker-compose.yml
+++ b/builds/develop/docker-compose.yml
@@ -151,6 +151,7 @@ services:
       KAFKA_BOOTSTRAP_SERVERS: kafka:5001
       GITHUB_TOKEN: ${GITHUB_TOKEN}
       INAPP_S3_BASE_URL: ${INAPP_S3_BASE_URL}
+      INAPP_S3_KEY_PREFIX: ${AWS_S3_KEY_PREFIX}
     depends_on:
       mysql:
         condition: service_healthy

--- a/services/service-file/src/main/kotlin/com/b1nd/dodamdodam/file/infrastructure/s3/S3FileStorageClient.kt
+++ b/services/service-file/src/main/kotlin/com/b1nd/dodamdodam/file/infrastructure/s3/S3FileStorageClient.kt
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Component
 import org.springframework.web.multipart.MultipartFile
 import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.ObjectCannedACL
 import software.amazon.awssdk.services.s3.model.PutObjectRequest
 import java.nio.file.Files
 import java.nio.file.Path
@@ -25,6 +26,11 @@ class S3FileStorageClient(
             .key(key)
             .contentType(contentType)
             .contentLength(file.size)
+            .apply {
+                if (properties.publicRead) {
+                    acl(ObjectCannedACL.PUBLIC_READ)
+                }
+            }
             .build()
 
         runCatching {

--- a/services/service-file/src/main/kotlin/com/b1nd/dodamdodam/file/infrastructure/s3/S3Properties.kt
+++ b/services/service-file/src/main/kotlin/com/b1nd/dodamdodam/file/infrastructure/s3/S3Properties.kt
@@ -11,4 +11,5 @@ data class S3Properties(
     val secretKey: String = "",
     val pathStyleAccess: Boolean = false,
     val keyPrefix: String = "",
+    val publicRead: Boolean = false,
 )

--- a/services/service-file/src/main/kotlin/com/b1nd/dodamdodam/file/infrastructure/s3/S3ReleaseUploader.kt
+++ b/services/service-file/src/main/kotlin/com/b1nd/dodamdodam/file/infrastructure/s3/S3ReleaseUploader.kt
@@ -3,6 +3,7 @@ package com.b1nd.dodamdodam.file.infrastructure.s3
 import org.springframework.stereotype.Component
 import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.ObjectCannedACL
 import software.amazon.awssdk.services.s3.model.PutObjectRequest
 import java.io.ByteArrayInputStream
 import java.util.*
@@ -32,6 +33,11 @@ class S3ReleaseUploader(
                             .key(key)
                             .contentType(contentType)
                             .contentLength(bytes.size.toLong())
+                            .apply {
+                                if (properties.publicRead) {
+                                    acl(ObjectCannedACL.PUBLIC_READ)
+                                }
+                            }
                             .build()
 
                         s3Client.putObject(request, RequestBody.fromBytes(bytes))

--- a/services/service-file/src/main/resources/application.yml
+++ b/services/service-file/src/main/resources/application.yml
@@ -38,6 +38,7 @@ cloud:
       secret-key: ${AWS_SECRET_KEY:}
       path-style-access: ${AWS_S3_PATH_STYLE:false}
       key-prefix: ${AWS_S3_KEY_PREFIX:}
+      public-read: ${AWS_S3_PUBLIC_READ:false}
 
 app:
   swagger:

--- a/services/service-inapp/src/main/kotlin/com/b1nd/dodamdodam/inapp/application/app/AppUseCase.kt
+++ b/services/service-inapp/src/main/kotlin/com/b1nd/dodamdodam/inapp/application/app/AppUseCase.kt
@@ -77,10 +77,17 @@ class AppUseCase(
     @Transactional(readOnly = true)
     fun getActiveApps(pageable: Pageable): Response<PageResponse<ActiveAppResponse>> {
         val appsWithRelease = appService.getActiveAppsWithRelease(pageable)
-        val s3BaseUrl = inAppProperties.s3BaseUrl
         return Response.ok(
             "서비스 목록을 조회했어요.",
-            PageResponse.of(appsWithRelease.map { it.app.toActiveAppResponse(it.releasePublicId, s3BaseUrl) })
+            PageResponse.of(
+                appsWithRelease.map {
+                    it.app.toActiveAppResponse(
+                        it.releasePublicId,
+                        inAppProperties.s3BaseUrl,
+                        inAppProperties.s3KeyPrefix,
+                    )
+                }
+            )
         )
     }
 

--- a/services/service-inapp/src/main/kotlin/com/b1nd/dodamdodam/inapp/application/app/data/AppMapper.kt
+++ b/services/service-inapp/src/main/kotlin/com/b1nd/dodamdodam/inapp/application/app/data/AppMapper.kt
@@ -87,17 +87,26 @@ fun AppEntity.toActiveAppResponse() = ActiveAppResponse(
     darkIconUrl = darkIconUrl,
 )
 
-fun AppEntity.toActiveAppResponse(releasePublicId: java.util.UUID?, s3BaseUrl: String?) = ActiveAppResponse(
+fun AppEntity.toActiveAppResponse(releasePublicId: UUID?, s3BaseUrl: String?, s3KeyPrefix: String?) = ActiveAppResponse(
     appId = publicId!!,
     name = name,
     subtitle = subtitle,
     description = description,
     iconUrl = iconUrl,
     darkIconUrl = darkIconUrl,
-    appUrl = if (!s3BaseUrl.isNullOrBlank() && releasePublicId != null) {
-        "${s3BaseUrl.trimEnd('/')}/inapp/$publicId/releases/$releasePublicId/index.html"
-    } else null,
+    appUrl = buildInAppWebViewUrl(s3BaseUrl, s3KeyPrefix, publicId, releasePublicId),
 )
+
+fun buildInAppWebViewUrl(s3BaseUrl: String?, s3KeyPrefix: String?, appPublicId: UUID?, releasePublicId: UUID?): String? {
+    if (s3BaseUrl.isNullOrBlank() || appPublicId == null || releasePublicId == null) {
+        return null
+    }
+
+    val prefix = s3KeyPrefix?.trim('/')?.takeIf { it.isNotBlank() }
+    val releasePath = "inapp/$appPublicId/releases/$releasePublicId/index.html"
+    val objectPath = listOfNotNull(prefix, releasePath).joinToString("/")
+    return "${s3BaseUrl.trimEnd('/')}/$objectPath"
+}
 
 fun CreateAppRequest.toCommand() = CreateAppCommand(
     teamId = teamId,

--- a/services/service-inapp/src/main/kotlin/com/b1nd/dodamdodam/inapp/infrastructure/config/InAppProperties.kt
+++ b/services/service-inapp/src/main/kotlin/com/b1nd/dodamdodam/inapp/infrastructure/config/InAppProperties.kt
@@ -5,4 +5,5 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 @ConfigurationProperties("inapp")
 data class InAppProperties(
     val s3BaseUrl: String = "",
+    val s3KeyPrefix: String = "",
 )

--- a/services/service-inapp/src/main/kotlin/com/b1nd/dodamdodam/inapp/infrastructure/grpc/server/AppQueryGrpcService.kt
+++ b/services/service-inapp/src/main/kotlin/com/b1nd/dodamdodam/inapp/infrastructure/grpc/server/AppQueryGrpcService.kt
@@ -3,6 +3,7 @@ package com.b1nd.dodamdodam.inapp.infrastructure.grpc.server
 import com.b1nd.dodamdodam.grpc.inapp.AppQueryServiceGrpcKt
 import com.b1nd.dodamdodam.grpc.inapp.GetAppRequest
 import com.b1nd.dodamdodam.grpc.inapp.GetAppResponse
+import com.b1nd.dodamdodam.inapp.application.app.data.buildInAppWebViewUrl
 import com.b1nd.dodamdodam.inapp.domain.app.repository.AppReleaseRepository
 import com.b1nd.dodamdodam.inapp.domain.app.service.AppService
 import com.b1nd.dodamdodam.inapp.infrastructure.config.InAppProperties
@@ -19,9 +20,12 @@ class AppQueryGrpcService(
     override suspend fun getApp(request: GetAppRequest): GetAppResponse {
         val app = appService.getApp(UUID.fromString(request.appPublicId))
         val activeRelease = appReleaseRepository.findAllByAppAndEnabledIsTrue(app).firstOrNull()
-        val appUrl = if (inAppProperties.s3BaseUrl.isNotBlank() && activeRelease != null) {
-            "${inAppProperties.s3BaseUrl.trimEnd('/')}/inapp/${app.publicId}/releases/${activeRelease.publicId}/index.html"
-        } else ""
+        val appUrl = buildInAppWebViewUrl(
+            inAppProperties.s3BaseUrl,
+            inAppProperties.s3KeyPrefix,
+            app.publicId,
+            activeRelease?.publicId,
+        ) ?: ""
 
         return GetAppResponse.newBuilder()
             .setAppPublicId(app.publicId.toString())

--- a/services/service-inapp/src/main/resources/application.yml
+++ b/services/service-inapp/src/main/resources/application.yml
@@ -25,6 +25,7 @@ management:
 
 inapp:
   s3-base-url: ${INAPP_S3_BASE_URL:}
+  s3-key-prefix: ${INAPP_S3_KEY_PREFIX:${AWS_S3_KEY_PREFIX:}}
 
 github:
   token: ${GITHUB_TOKEN:}


### PR DESCRIPTION
## 변경 내용

- AID 웹뷰 URL 생성 시 S3 업로드 경로와 동일하게 `AWS_S3_KEY_PREFIX`를 반영하도록 수정했습니다.
- `service-inapp`의 앱 목록 조회 및 gRPC 앱 조회 응답에서 동일한 웹뷰 URL 생성 로직을 사용하도록 정리했습니다.
- `service-file` S3 업로드 시 필요하면 `AWS_S3_PUBLIC_READ` 설정으로 `public-read` ACL을 적용할 수 있도록 옵션을 추가했습니다.
- develop docker-compose에 `INAPP_S3_KEY_PREFIX` 환경변수를 추가했습니다.

## 관련 이슈

- Resolves #223

## 테스트 방법

- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 완료
- [x] 수동 테스트 완료

실행한 검증 명령어: `./gradlew :services:service-inapp:compileKotlin :services:service-file:compileKotlin --no-daemon`

## 스크린샷 (UI 변경 시)

### Before

AID 웹뷰 진입 시 S3 AccessDenied 페이지가 표시됨

### After

서버에서 내려주는 AID 웹뷰 URL에 S3 key prefix가 반영되도록 수정됨

## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 완료했습니다
- [ ] 변경 사항에 대한 테스트를 추가했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] Breaking Changes가 없습니다

## 기타 사항

S3 버킷이 ACL 비활성화 상태라면 `AWS_S3_PUBLIC_READ`는 `false`로 유지하고, bucket policy 또는 CloudFront 정책으로 public read 접근을 허용해야 합니다.