### PR TITLE
hotfix: AID 웹뷰 S3 key prefix 기본값 설정 (#226)

### DIFF
--- a/services/service-inapp/src/main/resources/application-prod.yml
+++ b/services/service-inapp/src/main/resources/application-prod.yml
@@ -22,6 +22,9 @@ spring:
 server:
   port: 8080
 
+inapp:
+  s3-key-prefix: ${INAPP_S3_KEY_PREFIX:${AWS_S3_KEY_PREFIX:prod/static}}
+
 grpc:
   server:
     port: 9090


### PR DESCRIPTION
## 변경 내용

AID 웹뷰 진입 시 Access Denied가 발생하던 문제를 수정했습니다. service-inapp의 prod 프로필에 `inapp.s3-key-prefix` 기본값(`prod/static`)을 추가하여, k3s 배포 환경에 `INAPP_S3_KEY_PREFIX`/`AWS_S3_KEY_PREFIX` env가 주입되지 않아도 실제 S3 파일 위치와 일치하는 URL이 내려가도록 했습니다. env가 설정되어 있으면 기존처럼 env 값이 우선 적용됩니다.


## 관련 이슈
- Resolves #226


## 테스트 방법

- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 완료
- [x] 수동 테스트 완료

## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 완료했습니다
- [ ] 변경 사항에 대한 테스트를 추가했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] Breaking Changes가 없습니다


## 기타 사항
- 임시 fallback 값입니다. 근본적으로는 k3s Deployment(service-inapp)에 `INAPP_S3_KEY_PREFIX` env를 정식으로 설정하는 것이 필요합니다.
- 핫픽스로 main에 바로 머지합니다. develop에도 별도 반영 필요합니다.