### PR TITLE
hotfix: AID 웹뷰 S3 URL prefix 중복 방지 및 릴리즈 공개 설정 분리

### DIFF
--- a/services/service-file/src/main/kotlin/com/b1nd/dodamdodam/file/infrastructure/s3/S3Properties.kt
+++ b/services/service-file/src/main/kotlin/com/b1nd/dodamdodam/file/infrastructure/s3/S3Properties.kt
@@ -12,4 +12,5 @@ data class S3Properties(
     val pathStyleAccess: Boolean = false,
     val keyPrefix: String = "",
     val publicRead: Boolean = false,
+    val releasePublicRead: Boolean = true
 )

--- a/services/service-file/src/main/kotlin/com/b1nd/dodamdodam/file/infrastructure/s3/S3ReleaseUploader.kt
+++ b/services/service-file/src/main/kotlin/com/b1nd/dodamdodam/file/infrastructure/s3/S3ReleaseUploader.kt
@@ -34,7 +34,7 @@ class S3ReleaseUploader(
                             .contentType(contentType)
                             .contentLength(bytes.size.toLong())
                             .apply {
-                                if (properties.publicRead) {
+                                if (properties.releasePublicRead) {
                                     acl(ObjectCannedACL.PUBLIC_READ)
                                 }
                             }

--- a/services/service-file/src/main/resources/application.yml
+++ b/services/service-file/src/main/resources/application.yml
@@ -39,6 +39,7 @@ cloud:
       path-style-access: ${AWS_S3_PATH_STYLE:false}
       key-prefix: ${AWS_S3_KEY_PREFIX:}
       public-read: ${AWS_S3_PUBLIC_READ:false}
+      release-public-read: ${AWS_S3_RELEASE_PUBLIC_READ:true}
 
 app:
   swagger:

--- a/services/service-inapp/src/main/kotlin/com/b1nd/dodamdodam/inapp/application/app/data/AppMapper.kt
+++ b/services/service-inapp/src/main/kotlin/com/b1nd/dodamdodam/inapp/application/app/data/AppMapper.kt
@@ -102,7 +102,9 @@ fun buildInAppWebViewUrl(s3BaseUrl: String?, s3KeyPrefix: String?, appPublicId: 
         return null
     }
 
+    val base = s3BaseUrl.trimEnd('/')
     val prefix = s3KeyPrefix?.trim('/')?.takeIf { it.isNotBlank() }
+        ?.takeUnless { base.endsWith("/$it") }
     val releasePath = "inapp/$appPublicId/releases/$releasePublicId/index.html"
     val objectPath = listOfNotNull(prefix, releasePath).joinToString("/")
     return "${s3BaseUrl.trimEnd('/')}/$objectPath"


### PR DESCRIPTION
## 변경 내용
URL에서 prefix가 중복이 되지 않기 위해 방지하는 코드를 작성했습니다.
file에서 릴리즈의 한에서만 공개하도록 수정했습니다.
<!-- 이 PR에서 무엇을 변경했는지 간단히 요약해주세요 -->


## 관련 이슈

<!-- 관련된 이슈를 연결해주세요 -->
- Resolves #228 


## 테스트 방법

<!-- 어떻게 테스트했는지 설명해주세요 -->
- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 완료
- [x] 수동 테스트 완료

## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [ ] 자체 코드 리뷰를 완료했습니다
- [ ] 변경 사항에 대한 테스트를 추가했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [ ] Breaking Changes가 없습니다


## 기타 사항

<!-- 리뷰어가 특별히 주의해서 봐야 할 부분이나 추가 설명 -->