### PR TITLE
fix: clear stale token cookies on login

### DIFF
--- a/services/service-auth/src/main/kotlin/com/b1nd/dodamdodam/auth/application/auth/AuthUseCase.kt
+++ b/services/service-auth/src/main/kotlin/com/b1nd/dodamdodam/auth/application/auth/AuthUseCase.kt
@@ -35,6 +35,7 @@ class AuthUseCase(
         if (!principal.status) throw UserNotActiveException()
         val tokens = jwtSigner.createTokens(JwtClaims(principal.userId, principal.username))
         principalService.saveRefreshToken(principal, tokens.refreshToken, userAgent)
+        cookieProvider.clearStaleTokenCookies()
         cookieProvider.addTokenCookies(tokens.accessToken, tokens.refreshToken)
         return Response.ok("로그인에 성공했어요.", LoginResponse.fromJwtPair(tokens))
     }

--- a/services/service-auth/src/main/kotlin/com/b1nd/dodamdodam/auth/infrastructure/cookie/TokenCookieProvider.kt
+++ b/services/service-auth/src/main/kotlin/com/b1nd/dodamdodam/auth/infrastructure/cookie/TokenCookieProvider.kt
@@ -25,6 +25,20 @@ class TokenCookieProvider(
         response.addHeader(HttpHeaders.SET_COOKIE, createExpiredCookie(cookieProperties.refreshTokenName, cookieProperties.refreshTokenPath).toString())
     }
 
+    fun clearStaleTokenCookies() {
+        val response = currentResponse()
+        val names = listOf(cookieProperties.accessTokenName, cookieProperties.refreshTokenName)
+        val domains = listOf("", cookieProperties.domain).distinct()
+        val paths = listOf("/", cookieProperties.refreshTokenPath).distinct()
+        names.forEach { name ->
+            domains.forEach { domain ->
+                paths.forEach { path ->
+                    response.addHeader(HttpHeaders.SET_COOKIE, createExpiredCookie(name, path, domain).toString())
+                }
+            }
+        }
+    }
+
     private fun currentResponse() =
         (RequestContextHolder.getRequestAttributes() as ServletRequestAttributes).response!!
 
@@ -43,18 +57,22 @@ class TokenCookieProvider(
             .maxAge(cookieMaxAge())
             .build()
 
-    private fun createExpiredCookie(name: String, path: String): ResponseCookie =
-        buildCookie(name, "")
+    private fun createExpiredCookie(name: String, path: String, cookieDomain: String = cookieProperties.domain): ResponseCookie =
+        buildCookie(name, "", cookieDomain)
             .path(path)
             .maxAge(0)
             .build()
 
-    private fun buildCookie(name: String, value: String): ResponseCookie.ResponseCookieBuilder =
+    private fun buildCookie(
+        name: String,
+        value: String,
+        cookieDomain: String = cookieProperties.domain
+    ): ResponseCookie.ResponseCookieBuilder =
         ResponseCookie.from(name, value)
             .httpOnly(true)
             .secure(cookieProperties.secure)
             .sameSite(cookieProperties.sameSite)
             .apply {
-                cookieProperties.domain.takeIf { it.isNotBlank() }?.let { domain(it) }
+                cookieDomain.takeIf { it.isNotBlank() }?.let { domain(it) }
             }
 }


### PR DESCRIPTION
## 변경 내용
로그인 시 도메인/경로 조합이 다른 기존 토큰 쿠키를 모두 만료시킨 뒤 새 토큰 쿠키를 내려주도록 수정했습니다.
<!-- 이 PR에서 무엇을 변경했는지 간단히 요약해주세요 -->


## 관련 이슈

<!-- 관련된 이슈를 연결해주세요 -->
- Resolves #244 


## 테스트 방법

<!-- 어떻게 테스트했는지 설명해주세요 -->
- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 완료
- [x] 수동 테스트 완료


## 체크리스트

- [ ] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [ ] 자체 코드 리뷰를 완료했습니다
- [ ] 변경 사항에 대한 테스트를 추가했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [ ] Breaking Changes가 없습니다


## 기타 사항

<!-- 리뷰어가 특별히 주의해서 봐야 할 부분이나 추가 설명 -->