### PR TITLE
[HotFix] add GitHub production build scripts to tracked files

### DIFF
--- a/.github/scripts/production/build/notification.sh
+++ b/.github/scripts/production/build/notification.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd services/service-notification
+npm ci
+npm run build

--- a/.github/scripts/production/build/resolve-dockerfile.sh
+++ b/.github/scripts/production/build/resolve-dockerfile.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${SERVICE:?SERVICE is required}"
+: "${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+
+if [ -f "builds/develop/Dockerfile.${SERVICE}" ]; then
+  file="builds/develop/Dockerfile.${SERVICE}"
+else
+  file="builds/develop/Dockerfile"
+fi
+
+echo "file=${file}" >> "$GITHUB_OUTPUT"
+echo "Using ${file}"

--- a/.github/scripts/production/build/spring.sh
+++ b/.github/scripts/production/build/spring.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${SERVICE:?SERVICE is required}"
+
+chmod +x gradlew
+./gradlew ":services:service-${SERVICE}:build" -x test --no-daemon
+
+dir="services/service-${SERVICE}/build/libs"
+jar=$(find "$dir" -name "service-${SERVICE}-*.jar" ! -name "*-plain.jar" | head -1)
+
+if [ -z "$jar" ]; then
+  echo "No boot jar found for service-${SERVICE} in ${dir}" >&2
+  exit 1
+fi
+
+cp "$jar" "${dir}/service-${SERVICE}.jar"
+echo "Prepared ${dir}/service-${SERVICE}.jar"

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+!.github/scripts/production/build/
 
 ### IntelliJ IDEA ###
 .idea/modules.xml


### PR DESCRIPTION
## 변경 사항
- `.gitignore`에 `.github/scripts/production/build/` 디렉토리 예외 추가
- GitHub Actions 프로덕션 빌드 스크립트 파일 추가
  - `spring.sh`: Spring 애플리케이션 빌드 스크립트
  - `notification.sh`: 알림 관련 스크립트
  - `resolve-dockerfile.sh`: Dockerfile 경로 해석 스크립트

## 변경 이유
CI/CD 파이프라인에서 사용되는 프로덕션 빌드 스크립트를 버전 관리하고 팀원들과 공유하기 위함

## 테스트 방법
- [ ] GitHub Actions 워크플로우에서 스크립트가 정상적으로 실행되는지 확인
- [ ] 빌드 프로세스가 예상대로 동작하는지 검증

---