### PR TITLE
Feature: 실별 심야자습 조회 API 추가

### DIFF
--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/room/ProjectRoomUseCase.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/room/ProjectRoomUseCase.kt
@@ -2,10 +2,12 @@ package com.b1nd.dodamdodam.nightstudy.application.room
 
 import com.b1nd.dodamdodam.core.common.data.Response
 import com.b1nd.dodamdodam.nightstudy.application.room.data.request.SaveProjectRoomRequest
+import com.b1nd.dodamdodam.nightstudy.application.room.data.response.ProjectRoomResponse
 import com.b1nd.dodamdodam.nightstudy.application.room.data.response.RoomDetailResponse
 import com.b1nd.dodamdodam.nightstudy.application.room.data.response.RoomMemberResponse
 import com.b1nd.dodamdodam.nightstudy.application.room.data.response.RoomSummaryResponse
 import com.b1nd.dodamdodam.nightstudy.application.room.data.toEntity
+import com.b1nd.dodamdodam.nightstudy.application.room.data.toResponseList
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.command.NightStudyRoomMemberCommand
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.enumeration.NightStudyType
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.exception.InvalidNightStudyTypeException
@@ -41,7 +43,13 @@ class ProjectRoomUseCase(
     }
 
     @Transactional(readOnly = true)
-    fun getAll(date: LocalDate, period: Int): Response<List<RoomSummaryResponse>> {
+    fun getAll(): Response<List<ProjectRoomResponse>> {
+        val rooms = projectRoomService.getAll().toResponseList()
+        return Response.ok("방 목록을 조회했어요.", rooms)
+    }
+
+    @Transactional(readOnly = true)
+    fun getAllWithStatus(date: LocalDate, period: Int): Response<List<RoomSummaryResponse>> {
         val snapshot = createSnapshot(date, period)
         val rooms = snapshot.rooms.map { room ->
             val members = snapshot.membersByRoom[room.id].orEmpty()

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/room/ProjectRoomUseCase.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/room/ProjectRoomUseCase.kt
@@ -2,18 +2,38 @@ package com.b1nd.dodamdodam.nightstudy.application.room
 
 import com.b1nd.dodamdodam.core.common.data.Response
 import com.b1nd.dodamdodam.nightstudy.application.room.data.request.SaveProjectRoomRequest
-import com.b1nd.dodamdodam.nightstudy.application.room.data.response.ProjectRoomResponse
+import com.b1nd.dodamdodam.nightstudy.application.room.data.response.RoomDetailResponse
+import com.b1nd.dodamdodam.nightstudy.application.room.data.response.RoomMemberResponse
+import com.b1nd.dodamdodam.nightstudy.application.room.data.response.RoomSummaryResponse
 import com.b1nd.dodamdodam.nightstudy.application.room.data.toEntity
-import com.b1nd.dodamdodam.nightstudy.application.room.data.toResponseList
+import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.command.NightStudyRoomMemberCommand
+import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.enumeration.NightStudyType
+import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.exception.InvalidNightStudyTypeException
+import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.service.NightStudyAttendanceService
+import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.service.NightStudyService
+import com.b1nd.dodamdodam.nightstudy.domain.room.exception.ProjectRoomNotFoundException
 import com.b1nd.dodamdodam.nightstudy.domain.room.service.ProjectRoomService
+import com.b1nd.dodamdodam.nightstudy.infrastructure.user.client.UserQueryClient
+import kotlinx.coroutines.runBlocking
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+import java.util.UUID
 
 @Component
 @Transactional(rollbackFor = [Exception::class])
 class ProjectRoomUseCase(
     private val projectRoomService: ProjectRoomService,
+    private val nightStudyService: NightStudyService,
+    private val nightStudyAttendanceService: NightStudyAttendanceService,
+    private val userQueryClient: UserQueryClient,
 ) {
+
+    companion object {
+        private const val THIRD_GRADE_ROOM_ID = "GRADE_3"
+        private const val THIRD_GRADE_ROOM_NAME = "3학년 심자실"
+        private const val MAX_CLASS_ROOM = 4
+    }
 
     fun create(request: SaveProjectRoomRequest): Response<Any> {
         projectRoomService.save(request.toEntity())
@@ -21,9 +41,30 @@ class ProjectRoomUseCase(
     }
 
     @Transactional(readOnly = true)
-    fun getAll(): Response<List<ProjectRoomResponse>> {
-        val rooms = projectRoomService.getAll().toResponseList()
-        return Response.ok("방 목록을 조회했어요.", rooms)
+    fun getAll(date: LocalDate, period: Int): Response<List<RoomSummaryResponse>> {
+        val snapshot = createSnapshot(date, period)
+        val rooms = snapshot.rooms.map { room ->
+            val members = snapshot.membersByRoom[room.id].orEmpty()
+            RoomSummaryResponse(
+                roomId = room.id,
+                roomName = room.name,
+                memberCount = members.size,
+                unchecked = members.count { !it.attended },
+            )
+        }
+
+        return Response.ok("심야자습 실별 현황을 조회했어요.", rooms)
+    }
+
+    @Transactional(readOnly = true)
+    fun getByRoomId(roomId: String, date: LocalDate, period: Int): Response<RoomDetailResponse> {
+        val snapshot = createSnapshot(date, period)
+        if (snapshot.rooms.none { it.id == roomId }) throw ProjectRoomNotFoundException()
+
+        return Response.ok(
+            "심야자습 실 인원을 조회했어요.",
+            RoomDetailResponse(roomMember = snapshot.membersByRoom[roomId].orEmpty()),
+        )
     }
 
     fun update(id: Long, request: SaveProjectRoomRequest): Response<Any> {
@@ -35,4 +76,94 @@ class ProjectRoomUseCase(
         projectRoomService.delete(id)
         return Response.ok("방을 삭제했어요.")
     }
+
+    private fun createSnapshot(date: LocalDate, period: Int): RoomSnapshot {
+        validatePeriod(period)
+
+        val rooms = getRooms()
+        val validRoomIds = rooms.map { it.id }.toSet()
+        val assignments = nightStudyService.getAllowedRoomMembers(date, period)
+            .groupBy { it.userId }
+            .mapValues { (_, values) -> selectAssignment(values) }
+        val attendedUserIds = nightStudyAttendanceService.getAttendedUserIds(assignments.keys, date, period)
+        val users = if (assignments.isEmpty()) {
+            emptyList()
+        } else {
+            runBlocking { userQueryClient.getUsers(assignments.keys.map(UUID::toString)) }.usersList
+        }
+
+        val membersByRoom = users.mapNotNull { user ->
+            val userId = UUID.fromString(user.publicId)
+            val assignment = assignments[userId] ?: return@mapNotNull null
+            if (!user.hasStudent()) return@mapNotNull null
+            val student = user.student
+            val roomId = resolveRoomId(assignment, student.grade, student.room)
+                ?.takeIf { it in validRoomIds }
+                ?: return@mapNotNull null
+
+            roomId to RoomMemberResponse(
+                userId = userId,
+                name = user.name,
+                profileImage = user.profileImage.takeIf { it.isNotBlank() },
+                grade = student.grade,
+                room = student.room,
+                number = student.number,
+                attended = userId in attendedUserIds,
+            )
+        }.groupBy(
+            keySelector = { it.first },
+            valueTransform = { it.second },
+        ).mapValues { (_, members) ->
+            members.sortedWith(compareBy(RoomMemberResponse::grade, RoomMemberResponse::room, RoomMemberResponse::number))
+        }
+
+        return RoomSnapshot(rooms = rooms, membersByRoom = membersByRoom)
+    }
+
+    private fun getRooms(): List<RoomDefinition> {
+        val classRooms = (1..2).flatMap { grade ->
+            (1..MAX_CLASS_ROOM).map { room ->
+                RoomDefinition(id = "CLASS_${grade}_$room", name = "${grade}학년 ${room}반")
+            }
+        }
+        val thirdGradeRoom = RoomDefinition(id = THIRD_GRADE_ROOM_ID, name = THIRD_GRADE_ROOM_NAME)
+        val projectRooms = projectRoomService.getAll()
+            .sortedBy { it.name }
+            .map { RoomDefinition(id = "PROJECT_${it.id!!}", name = it.name) }
+
+        return classRooms + thirdGradeRoom + projectRooms
+    }
+
+    private fun selectAssignment(assignments: List<NightStudyRoomMemberCommand>): NightStudyRoomMemberCommand {
+        return assignments.firstOrNull {
+            it.type == NightStudyType.PROJECT && it.projectRoomId != null
+        } ?: assignments.firstOrNull { it.type == NightStudyType.PERSONAL }
+        ?: assignments.first()
+    }
+
+    private fun resolveRoomId(assignment: NightStudyRoomMemberCommand, grade: Int, room: Int): String? {
+        if (assignment.type == NightStudyType.PROJECT && assignment.projectRoomId != null) {
+            return "PROJECT_${assignment.projectRoomId}"
+        }
+
+        return when (grade) {
+            1, 2 -> "CLASS_${grade}_$room"
+            3 -> THIRD_GRADE_ROOM_ID
+            else -> null
+        }
+    }
+
+    private fun validatePeriod(period: Int) {
+        if (period !in 1..2) throw InvalidNightStudyTypeException()
+    }
+
+    private data class RoomDefinition(
+        val id: String,
+        val name: String,
+    )
+
+    private data class RoomSnapshot(
+        val rooms: List<RoomDefinition>,
+        val membersByRoom: Map<String, List<RoomMemberResponse>>,
+    )
 }

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/room/data/response/RoomDetailResponse.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/room/data/response/RoomDetailResponse.kt
@@ -1,0 +1,17 @@
+package com.b1nd.dodamdodam.nightstudy.application.room.data.response
+
+import java.util.UUID
+
+data class RoomDetailResponse(
+    val roomMember: List<RoomMemberResponse>,
+)
+
+data class RoomMemberResponse(
+    val userId: UUID,
+    val name: String,
+    val profileImage: String?,
+    val grade: Int,
+    val room: Int,
+    val number: Int,
+    val attended: Boolean,
+)

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/room/data/response/RoomSummaryResponse.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/room/data/response/RoomSummaryResponse.kt
@@ -1,0 +1,8 @@
+package com.b1nd.dodamdodam.nightstudy.application.room.data.response
+
+data class RoomSummaryResponse(
+    val roomId: String,
+    val roomName: String,
+    val memberCount: Int,
+    val unchecked: Int,
+)

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/command/NightStudyRoomMemberCommand.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/command/NightStudyRoomMemberCommand.kt
@@ -1,0 +1,10 @@
+package com.b1nd.dodamdodam.nightstudy.domain.nightstudy.command
+
+import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.enumeration.NightStudyType
+import java.util.UUID
+
+data class NightStudyRoomMemberCommand(
+    val userId: UUID,
+    val type: NightStudyType,
+    val projectRoomId: Long?,
+)

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyAttendanceRepository.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyAttendanceRepository.kt
@@ -8,4 +8,9 @@ import java.util.UUID
 interface NightStudyAttendanceRepository: JpaRepository<NightStudyAttendanceEntity, Long> {
     fun findByUserIdAndDateAndPeriod(userId: UUID, date: LocalDate, period: Int): NightStudyAttendanceEntity?
     fun findAllByDateAndAttendedIsTrue(date: LocalDate): List<NightStudyAttendanceEntity>
+    fun findAllByUserIdInAndDateAndPeriodAndAttendedIsTrue(
+        userIds: Collection<UUID>,
+        date: LocalDate,
+        period: Int,
+    ): List<NightStudyAttendanceEntity>
 }

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepository.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepository.kt
@@ -1,6 +1,7 @@
 package com.b1nd.dodamdodam.nightstudy.domain.nightstudy.repository.nightStudy
 
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.entity.NightStudyEntity
+import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.command.NightStudyRoomMemberCommand
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.enumeration.NightStudyStatusType
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.enumeration.NightStudyType
 import org.springframework.data.domain.Page
@@ -19,6 +20,7 @@ interface NightStudyQueryRepository {
     fun existsByUserIdAndPeriodOverlap(userId: UUID, period: Int, type: NightStudyType, startAt: LocalDate, endAt: LocalDate): Boolean
     fun existsAllowedMemberByUserIdAndDateAndPeriod(userId: UUID, date: LocalDate, period: Int): Boolean
     fun findAllowedUserIdsByDateAndPeriod(date: LocalDate, period: Int): List<UUID>
+    fun findAllowedRoomMembersByDateAndPeriod(date: LocalDate, period: Int): List<NightStudyRoomMemberCommand>
     fun countAttendedUserIdsByDateAndPeriod(date: LocalDate, period: Int, userIds: List<UUID>): Long
     fun existsByRoomAndPeriodOverlap(roomId: Long, period: Int, startAt: LocalDate, endAt: LocalDate, excludeNightStudyId: Long): Boolean
     fun findActivePersonalsByUserIdsAndPeriodOverlap(userIds: List<UUID>, period: Int, startAt: LocalDate, endAt: LocalDate): List<NightStudyEntity>

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepositoryImpl.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.b1nd.dodamdodam.nightstudy.domain.nightstudy.repository.nightStudy
 
+import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.command.NightStudyRoomMemberCommand
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.entity.NightStudyEntity
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.entity.QNightStudyAttendanceEntity.nightStudyAttendanceEntity
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.entity.QNightStudyEntity
@@ -169,6 +170,38 @@ class NightStudyQueryRepositoryImpl(
             )
             .distinct()
             .fetch()
+    }
+
+    override fun findAllowedRoomMembersByDateAndPeriod(
+        date: LocalDate,
+        period: Int,
+    ): List<NightStudyRoomMemberCommand> {
+        val projectRoom = QProjectRoomEntity("roomForMember")
+
+        return queryFactory
+            .select(
+                nightStudyMemberEntity.userId,
+                nightStudyEntity.type,
+                projectRoom.id,
+            )
+            .from(nightStudyMemberEntity)
+            .join(nightStudyMemberEntity.nightStudy, nightStudyEntity)
+            .leftJoin(nightStudyEntity.room, projectRoom)
+            .where(
+                nightStudyEntity.status.eq(NightStudyStatusType.ALLOWED),
+                nightStudyEntity.period.goe(period),
+                nightStudyEntity.startAt.loe(date),
+                nightStudyEntity.endAt.goe(date),
+            )
+            .distinct()
+            .fetch()
+            .map { tuple ->
+                NightStudyRoomMemberCommand(
+                    userId = tuple.get(nightStudyMemberEntity.userId)!!,
+                    type = tuple.get(nightStudyEntity.type)!!,
+                    projectRoomId = tuple.get(projectRoom.id),
+                )
+            }
     }
 
     override fun countAttendedUserIdsByDateAndPeriod(date: LocalDate, period: Int, userIds: List<UUID>): Long {

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyAttendanceService.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyAttendanceService.kt
@@ -51,6 +51,15 @@ class NightStudyAttendanceService(
         return attendedCount to (allowedUserIds.size - attendedCount)
     }
 
+    fun getAttendedUserIds(userIds: Collection<UUID>, date: LocalDate, period: Int): Set<UUID> {
+        if (userIds.isEmpty()) return emptySet()
+
+        return attendanceRepository
+            .findAllByUserIdInAndDateAndPeriodAndAttendedIsTrue(userIds, date, period)
+            .map { it.userId }
+            .toSet()
+    }
+
     private fun validateAllowedMember(userId: UUID, date: LocalDate, period: Int) {
         if (!nightStudyQueryRepository.existsAllowedMemberByUserIdAndDateAndPeriod(userId, date, period)) {
             throw BasicException(NightStudyExceptionCode.NOT_NIGHT_STUDY_MEMBER)

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyService.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyService.kt
@@ -1,6 +1,7 @@
 package com.b1nd.dodamdodam.nightstudy.domain.nightstudy.service
 
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.entity.NightStudyEntity
+import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.command.NightStudyRoomMemberCommand
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.entity.NightStudyMemberEntity
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.enumeration.NightStudyStatusType
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.enumeration.NightStudyType
@@ -64,6 +65,10 @@ class NightStudyService(
 
     fun countAllowedMembersGroupByTypeAndPeriod(): Map<Pair<NightStudyType, Int>, Int> {
         return nightStudyQueryRepository.countAllowedMembersGroupByTypeAndPeriod()
+    }
+
+    fun getAllowedRoomMembers(date: LocalDate, period: Int): List<NightStudyRoomMemberCommand> {
+        return nightStudyQueryRepository.findAllowedRoomMembersByDateAndPeriod(date, period)
     }
 
     fun searchByType(type: NightStudyType, userIds: List<UUID>?, status: NightStudyStatusType?): List<NightStudyEntity> {

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/presentation/room/ProjectRoomController.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/presentation/room/ProjectRoomController.kt
@@ -5,9 +5,12 @@ import com.b1nd.dodamdodam.core.security.annotation.authentication.UserAccess
 import com.b1nd.dodamdodam.core.security.passport.enumerations.RoleType
 import com.b1nd.dodamdodam.nightstudy.application.room.ProjectRoomUseCase
 import com.b1nd.dodamdodam.nightstudy.application.room.data.request.SaveProjectRoomRequest
-import com.b1nd.dodamdodam.nightstudy.application.room.data.response.ProjectRoomResponse
+import com.b1nd.dodamdodam.nightstudy.application.room.data.response.RoomDetailResponse
+import com.b1nd.dodamdodam.nightstudy.application.room.data.response.RoomSummaryResponse
 import jakarta.validation.Valid
+import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.web.bind.annotation.*
+import java.time.LocalDate
 
 @RestController
 @RequestMapping("/rooms")
@@ -22,8 +25,20 @@ class ProjectRoomController(
 
     @UserAccess(roles = [RoleType.DORMITORY_MANAGER])
     @GetMapping
-    fun getAll(): Response<List<ProjectRoomResponse>> =
-        projectRoomUseCase.getAll()
+    fun getAll(
+        @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") date: LocalDate?,
+        @RequestParam period: Int,
+    ): Response<List<RoomSummaryResponse>> =
+        projectRoomUseCase.getAll(date ?: LocalDate.now(), period)
+
+    @UserAccess(roles = [RoleType.DORMITORY_MANAGER])
+    @GetMapping("/{roomId}")
+    fun getByRoomId(
+        @PathVariable roomId: String,
+        @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") date: LocalDate?,
+        @RequestParam period: Int,
+    ): Response<RoomDetailResponse> =
+        projectRoomUseCase.getByRoomId(roomId, date ?: LocalDate.now(), period)
 
     @UserAccess(roles = [RoleType.DORMITORY_MANAGER])
     @PatchMapping("/{id}")

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/presentation/room/ProjectRoomController.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/presentation/room/ProjectRoomController.kt
@@ -5,6 +5,7 @@ import com.b1nd.dodamdodam.core.security.annotation.authentication.UserAccess
 import com.b1nd.dodamdodam.core.security.passport.enumerations.RoleType
 import com.b1nd.dodamdodam.nightstudy.application.room.ProjectRoomUseCase
 import com.b1nd.dodamdodam.nightstudy.application.room.data.request.SaveProjectRoomRequest
+import com.b1nd.dodamdodam.nightstudy.application.room.data.response.ProjectRoomResponse
 import com.b1nd.dodamdodam.nightstudy.application.room.data.response.RoomDetailResponse
 import com.b1nd.dodamdodam.nightstudy.application.room.data.response.RoomSummaryResponse
 import jakarta.validation.Valid
@@ -25,14 +26,19 @@ class ProjectRoomController(
 
     @UserAccess(roles = [RoleType.DORMITORY_MANAGER])
     @GetMapping
-    fun getAll(
+    fun getAll(): Response<List<ProjectRoomResponse>> =
+        projectRoomUseCase.getAll()
+
+    @UserAccess(roles = [RoleType.DORMITORY_MANAGER])
+    @GetMapping("/status")
+    fun getAllWithStatus(
         @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") date: LocalDate?,
         @RequestParam period: Int,
     ): Response<List<RoomSummaryResponse>> =
-        projectRoomUseCase.getAll(date ?: LocalDate.now(), period)
+        projectRoomUseCase.getAllWithStatus(date ?: LocalDate.now(), period)
 
     @UserAccess(roles = [RoleType.DORMITORY_MANAGER])
-    @GetMapping("/{roomId}")
+    @GetMapping("/status/{roomId}")
     fun getByRoomId(
         @PathVariable roomId: String,
         @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") date: LocalDate?,

--- a/services/service-nightstudy/src/test/kotlin/com/b1nd/dodamdodam/nightstudy/application/room/ProjectRoomUseCaseTest.kt
+++ b/services/service-nightstudy/src/test/kotlin/com/b1nd/dodamdodam/nightstudy/application/room/ProjectRoomUseCaseTest.kt
@@ -50,7 +50,7 @@ class ProjectRoomUseCaseTest {
             student(secondUserId, "두 번째 학생", grade = 3, room = 4, number = 2),
         )
 
-        val response = useCase.getAll(date, 1)
+        val response = useCase.getAllWithStatus(date, 1)
         val thirdGradeRoom = response.data!!.single { it.roomId == "GRADE_3" }
 
         assertEquals(2, thirdGradeRoom.memberCount)
@@ -74,7 +74,7 @@ class ProjectRoomUseCaseTest {
         `when`(attendanceService.getAttendedUserIds(setOf(userId), date, 2)).thenReturn(emptySet())
         stubUsers(student(userId, "프로젝트 학생", grade = 1, room = 1, number = 1))
 
-        val response = useCase.getAll(date, 2)
+        val response = useCase.getAllWithStatus(date, 2)
         val project = response.data!!.single { it.roomId == "PROJECT_12" }
         val classRoom = response.data!!.single { it.roomId == "CLASS_1_1" }
 

--- a/services/service-nightstudy/src/test/kotlin/com/b1nd/dodamdodam/nightstudy/application/room/ProjectRoomUseCaseTest.kt
+++ b/services/service-nightstudy/src/test/kotlin/com/b1nd/dodamdodam/nightstudy/application/room/ProjectRoomUseCaseTest.kt
@@ -1,0 +1,115 @@
+package com.b1nd.dodamdodam.nightstudy.application.room
+
+import com.b1nd.dodamdodam.grpc.user.GetUsersResponse
+import com.b1nd.dodamdodam.grpc.user.StudentInfo
+import com.b1nd.dodamdodam.grpc.user.UserResponse
+import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.command.NightStudyRoomMemberCommand
+import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.enumeration.NightStudyType
+import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.service.NightStudyAttendanceService
+import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.service.NightStudyService
+import com.b1nd.dodamdodam.nightstudy.domain.room.entity.ProjectRoomEntity
+import com.b1nd.dodamdodam.nightstudy.domain.room.service.ProjectRoomService
+import com.b1nd.dodamdodam.nightstudy.infrastructure.user.client.UserQueryClient
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.anyList
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
+import java.time.LocalDate
+import java.util.UUID
+
+class ProjectRoomUseCaseTest {
+    private val projectRoomService = mock(ProjectRoomService::class.java)
+    private val nightStudyService = mock(NightStudyService::class.java)
+    private val attendanceService = mock(NightStudyAttendanceService::class.java)
+    private val userQueryClient = mock(UserQueryClient::class.java)
+    private val useCase = ProjectRoomUseCase(
+        projectRoomService = projectRoomService,
+        nightStudyService = nightStudyService,
+        nightStudyAttendanceService = attendanceService,
+        userQueryClient = userQueryClient,
+    )
+
+    @Test
+    fun `3학년은 반에 관계없이 하나의 심자실로 분류한다`() {
+        val date = LocalDate.of(2026, 8, 1)
+        val firstUserId = UUID.randomUUID()
+        val secondUserId = UUID.randomUUID()
+        val assignments = listOf(
+            personalAssignment(firstUserId),
+            personalAssignment(secondUserId),
+        )
+
+        `when`(projectRoomService.getAll()).thenReturn(emptyList())
+        `when`(nightStudyService.getAllowedRoomMembers(date, 1)).thenReturn(assignments)
+        `when`(attendanceService.getAttendedUserIds(setOf(firstUserId, secondUserId), date, 1))
+            .thenReturn(setOf(firstUserId))
+        stubUsers(
+            student(firstUserId, "첫 번째 학생", grade = 3, room = 1, number = 1),
+            student(secondUserId, "두 번째 학생", grade = 3, room = 4, number = 2),
+        )
+
+        val response = useCase.getAll(date, 1)
+        val thirdGradeRoom = response.data!!.single { it.roomId == "GRADE_3" }
+
+        assertEquals(2, thirdGradeRoom.memberCount)
+        assertEquals(1, thirdGradeRoom.unchecked)
+    }
+
+    @Test
+    fun `프로젝트 심자와 개인 심자가 중복되면 프로젝트실에만 배정한다`() {
+        val date = LocalDate.of(2026, 8, 1)
+        val userId = UUID.randomUUID()
+        val projectRoom = mock(ProjectRoomEntity::class.java)
+        val assignments = listOf(
+            personalAssignment(userId),
+            NightStudyRoomMemberCommand(userId, NightStudyType.PROJECT, projectRoomId = 12L),
+        )
+
+        `when`(projectRoom.id).thenReturn(12L)
+        `when`(projectRoom.name).thenReturn("LAB13")
+        `when`(projectRoomService.getAll()).thenReturn(listOf(projectRoom))
+        `when`(nightStudyService.getAllowedRoomMembers(date, 2)).thenReturn(assignments)
+        `when`(attendanceService.getAttendedUserIds(setOf(userId), date, 2)).thenReturn(emptySet())
+        stubUsers(student(userId, "프로젝트 학생", grade = 1, room = 1, number = 1))
+
+        val response = useCase.getAll(date, 2)
+        val project = response.data!!.single { it.roomId == "PROJECT_12" }
+        val classRoom = response.data!!.single { it.roomId == "CLASS_1_1" }
+
+        assertEquals(1, project.memberCount)
+        assertEquals(1, project.unchecked)
+        assertEquals(0, classRoom.memberCount)
+    }
+
+    private fun personalAssignment(userId: UUID) = NightStudyRoomMemberCommand(
+        userId = userId,
+        type = NightStudyType.PERSONAL,
+        projectRoomId = null,
+    )
+
+    private fun student(
+        userId: UUID,
+        name: String,
+        grade: Int,
+        room: Int,
+        number: Int,
+    ): UserResponse = UserResponse.newBuilder()
+        .setPublicId(userId.toString())
+        .setName(name)
+        .setStudent(
+            StudentInfo.newBuilder()
+                .setGrade(grade)
+                .setRoom(room)
+                .setNumber(number)
+        )
+        .build()
+
+    private fun stubUsers(vararg users: UserResponse) {
+        val response = GetUsersResponse.newBuilder().addAllUsers(users.toList()).build()
+        runBlocking {
+            `when`(userQueryClient.getUsers(anyList())).thenReturn(response)
+        }
+    }
+}


### PR DESCRIPTION
## 변경 내용

- 실별 심야자습 현황 조회 API를 추가했습니다.
  - `GET /rooms`
  - `GET /rooms/{roomId}`
- 1·2학년은 각 반, 3학년은 하나의 심자실로 분류했습니다.
- 프로젝트 심자와 개인 심자가 중복되면 프로젝트실을 우선하도록 처리했습니다.
- 실별 전체 인원과 출석 미체크 인원을 집계합니다.
- 실 상세 조회에서 학생 정보와 출석 여부를 제공합니다.

## 관련 이슈

- Resolves #261

## 테스트 방법

- [x] 단위 테스트 추가/수정
- [ ] 통합 테스트 완료
- [ ] 수동 테스트 완료

```shell
./gradlew :services:service-nightstudy:check --no-daemon
```

## 스크린샷 (UI 변경 시)

해당 없음

## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 완료했습니다
- [x] 변경 사항에 대한 테스트를 추가했습니다
- [x] 문서를 업데이트했습니다 (필요한 경우)
- [ ] Breaking Changes가 없습니다

## 기타 사항

기존 `GET /rooms` 프로젝트실 목록 API의 응답 형식이 실별 심야자습 현황 형식으로 변경되었습니다.

또한 조회 기준을 지정하기 위해 `period` 쿼리 파라미터가 필수로 추가되었습니다.

실 식별자는 다음 형식을 사용합니다.

- `CLASS_1_1`: 1학년 1반
- `GRADE_3`: 3학년 심자실
- `PROJECT_12`: 프로젝트실