### PR TITLE
feat: 프로젝트 심자 신청 목록을 신청 시간순으로 정렬

### DIFF
--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/NightStudyUseCase.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/NightStudyUseCase.kt
@@ -94,11 +94,21 @@ class NightStudyUseCase(
         val usersMap = fetchUsersMap(visibleNightStudies)
         val projectMemberNightStudyIds = nightStudyService.getProjectMemberNightStudyIds(allNightStudies)
 
-        val sorted = visibleNightStudies.sortedWith(compareBy(
-            { usersMap[it.leaderId?.toString()]?.student?.grade ?: Int.MAX_VALUE },
-            { usersMap[it.leaderId?.toString()]?.student?.room ?: Int.MAX_VALUE },
-            { usersMap[it.leaderId?.toString()]?.student?.number ?: Int.MAX_VALUE }
-        ))
+        val sorted = if (type == NightStudyType.PROJECT) {
+            visibleNightStudies.sortedWith(
+                compareBy<NightStudyWithMembersCommand> {
+                    it.nightStudy.createdAt ?: LocalDateTime.MAX
+                }.thenBy {
+                    it.nightStudy.id ?: Long.MAX_VALUE
+                }
+            )
+        } else {
+            visibleNightStudies.sortedWith(compareBy(
+                { usersMap[it.leaderId?.toString()]?.student?.grade ?: Int.MAX_VALUE },
+                { usersMap[it.leaderId?.toString()]?.student?.room ?: Int.MAX_VALUE },
+                { usersMap[it.leaderId?.toString()]?.student?.number ?: Int.MAX_VALUE }
+            ))
+        }
 
         val offset = pageable.offset.toInt()
         val pageSize = pageable.pageSize


### PR DESCRIPTION
## 변경 내용

- 프로젝트 심자 신청 목록을 신청 생성 시간(`createdAt`) 기준 오름차순으로 정렬하도록 변경했습니다.
- 생성 시간이 같은 경우 ID 오름차순으로 정렬하여 일관된 순서를 보장합니다.
- 개인 심자 신청 목록의 기존 학년, 반, 번호순 정렬은 유지합니다.


## 관련 이슈

- Resolves #278


## 테스트 방법

- [ ] 단위 테스트 추가/수정
- [x] 기존 테스트 완료
- [ ] 수동 테스트 완료

실행 명령:

`./gradlew :services:service-nightstudy:test --no-daemon`

결과: `BUILD SUCCESSFUL`


## 스크린샷 (UI 변경 시)

서버 정렬 로직 변경으로 해당 사항이 없습니다.


## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 완료했습니다
- [ ] 변경 사항에 대한 테스트를 추가했습니다
- [x] 문서를 업데이트했습니다 (문서 변경 불필요)
- [x] Breaking Changes가 없습니다


## 기타 사항

- 프로젝트 심자 신청은 먼저 신청한 항목부터 표시됩니다 (`createdAt ASC`).
- 생성 시간이 동일한 경우 `id ASC`를 보조 정렬 기준으로 사용합니다.
- 개인 심자 신청 목록의 정렬 방식에는 영향을 주지 않습니다.