### PR TITLE
feat: 심자 인원 조회 집계 기준 변경

### DIFF
--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/NightStudyUseCase.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/NightStudyUseCase.kt
@@ -177,9 +177,9 @@ class NightStudyUseCase(
     }
 
     fun countTotalMembers(): Response<NightStudyTotalCountResponse> {
-        val nightStudys = nightStudyService.getAllAllowed()
+        val nightStudies = nightStudyService.getAllAllowed()
 
-        val membersByNightStudy = nightStudyService.getMembersByNightStudies(nightStudys)
+        val membersByNightStudy = nightStudyService.getMembersByNightStudies(nightStudies)
         val userIds = membersByNightStudy.values.flatten()
             .map { it.toString() }
             .distinct()
@@ -187,21 +187,50 @@ class NightStudyUseCase(
         val userById = runBlocking { userQueryClient.getUsers(userIds) }.usersList
             .associateBy { it.publicId }
 
-        val counts = nightStudys.flatMap { nightStudy ->
+        val members = nightStudies.flatMap { nightStudy ->
             val memberIds = membersByNightStudy[nightStudy.id] ?: emptyList()
 
-            memberIds.map { memberId ->
-                val user = userById[memberId.toString()]
-                Triple(
-                    resolveFloor(nightStudy, user),
-                    nightStudy.type,
-                    nightStudy.period,
+            memberIds.flatMap { memberId ->
+                periodsIncludedBy(nightStudy.period).map { period ->
+                    CountCandidate(memberId, period, nightStudy)
+                }
+            }
+        }.groupBy { it.userId to it.period }
+            .mapNotNull { (_, candidates) ->
+                val selected = candidates.maxWithOrNull(
+                    compareBy<CountCandidate>(
+                        { it.nightStudy.type == NightStudyType.PROJECT },
+                        { it.nightStudy.period == it.period },
+                    )
+                ) ?: return@mapNotNull null
+                val user = userById[selected.userId.toString()]
+                    ?.takeIf { it.hasStudent() }
+                    ?: return@mapNotNull null
+                val grade = user.student.grade.takeIf { it in 1..3 }
+                    ?: return@mapNotNull null
+
+                NightStudyTotalCountResponse.MemberCount(
+                    floor = resolveFloor(selected.nightStudy, user),
+                    grade = grade,
+                    period = selected.period,
+                    gender = NightStudyTotalCountResponse.Gender.MALE,
                 )
             }
-        }.groupingBy { it }.eachCount()
 
-        return Response.ok("심자 층별 인원수를 조회했어요.", NightStudyTotalCountResponse.of(counts))
+        return Response.ok("심자 인원수를 조회했어요.", NightStudyTotalCountResponse.of(members))
     }
+
+    private fun periodsIncludedBy(period: Int): List<Int> = when (period) {
+        1 -> listOf(1)
+        2 -> listOf(1, 2)
+        else -> emptyList()
+    }
+
+    private data class CountCandidate(
+        val userId: UUID,
+        val period: Int,
+        val nightStudy: NightStudyEntity,
+    )
 
     private fun resolveFloor(nightStudy: NightStudyEntity, user: UserResponse?): Int =
         if (nightStudy.type == NightStudyType.PROJECT) {

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/data/response/NightStudyTotalCountResponse.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/data/response/NightStudyTotalCountResponse.kt
@@ -1,9 +1,8 @@
 package com.b1nd.dodamdodam.nightstudy.application.nightstudy.data.response
 
-import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.enumeration.NightStudyType
-
 data class NightStudyTotalCountResponse(
     val floors: List<FloorCount>,
+    val grades: List<GradeCount>,
     val total: PeriodCount,
 ) {
     data class FloorCount(
@@ -11,42 +10,63 @@ data class NightStudyTotalCountResponse(
         val count: PeriodCount,
     )
 
-    data class PeriodCount(
-        val period1: TypeCount,
-        val period2: TypeCount,
+    data class GradeCount(
+        val grade: Int,
+        val count: PeriodCount,
     )
 
-    data class TypeCount(
-        val personal: Int,
-        val project: Int,
+    data class PeriodCount(
+        val period1: GenderCount,
+        val period2: GenderCount,
     )
+
+    data class GenderCount(
+        val male: Int,
+        val female: Int,
+    )
+
+    data class MemberCount(
+        val floor: Int,
+        val grade: Int,
+        val period: Int,
+        val gender: Gender,
+    )
+
+    enum class Gender {
+        MALE,
+        FEMALE,
+    }
 
     companion object {
-        fun of(count: Map<Triple<Int, NightStudyType, Int>, Int>): NightStudyTotalCountResponse {
-            fun typeCount(floor: Int, vararg periods: Int) = TypeCount(
-                personal = periods.sumOf { count[Triple(floor, NightStudyType.PERSONAL, it)] ?: 0 },
-                project = periods.sumOf { count[Triple(floor, NightStudyType.PROJECT, it)] ?: 0 },
+        fun of(members: List<MemberCount>): NightStudyTotalCountResponse {
+            fun genderCount(filtered: List<MemberCount>, period: Int) = GenderCount(
+                male = filtered.count { it.period == period && it.gender == Gender.MALE },
+                female = filtered.count { it.period == period && it.gender == Gender.FEMALE },
             )
-            fun periodCount(floor: Int) = PeriodCount(
-                period1 = typeCount(floor, 1, 2),
-                period2 = typeCount(floor, 2),
+
+            fun periodCount(filtered: List<MemberCount>) = PeriodCount(
+                period1 = genderCount(filtered, 1),
+                period2 = genderCount(filtered, 2),
             )
 
             val floors = listOf(2, 3).map { floor ->
-                FloorCount(floor = floor, count = periodCount(floor))
+                FloorCount(
+                    floor = floor,
+                    count = periodCount(members.filter { it.floor == floor }),
+                )
             }
-            val total = PeriodCount(
-                period1 = TypeCount(
-                    personal = floors.sumOf { it.count.period1.personal },
-                    project = floors.sumOf { it.count.period1.project },
-                ),
-                period2 = TypeCount(
-                    personal = floors.sumOf { it.count.period2.personal },
-                    project = floors.sumOf { it.count.period2.project },
-                ),
-            )
+            val grades = (1..3).map { grade ->
+                GradeCount(
+                    grade = grade,
+                    count = periodCount(members.filter { it.grade == grade }),
+                )
+            }
 
-            return NightStudyTotalCountResponse(floors = floors, total = total)
+            return NightStudyTotalCountResponse(
+                floors = floors,
+                grades = grades,
+                total = periodCount(members),
+            )
         }
     }
 }

--- a/services/service-nightstudy/src/test/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/NightStudyUseCaseCountTest.kt
+++ b/services/service-nightstudy/src/test/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/NightStudyUseCaseCountTest.kt
@@ -1,0 +1,99 @@
+package com.b1nd.dodamdodam.nightstudy.application.nightstudy
+
+import com.b1nd.dodamdodam.grpc.user.GetUsersResponse
+import com.b1nd.dodamdodam.grpc.user.StudentInfo
+import com.b1nd.dodamdodam.grpc.user.UserResponse
+import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.entity.NightStudyEntity
+import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.enumeration.NightStudyType
+import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.service.NightStudyAttendanceService
+import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.service.NightStudyService
+import com.b1nd.dodamdodam.nightstudy.domain.room.entity.ProjectRoomEntity
+import com.b1nd.dodamdodam.nightstudy.domain.room.service.ProjectRoomService
+import com.b1nd.dodamdodam.nightstudy.infrastructure.outSleeping.client.OutSleepingClient
+import com.b1nd.dodamdodam.nightstudy.infrastructure.user.client.UserQueryClient
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.anyList
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
+import java.util.UUID
+
+class NightStudyUseCaseCountTest {
+    private val nightStudyService = mock(NightStudyService::class.java)
+    private val nightStudyAttendanceService = mock(NightStudyAttendanceService::class.java)
+    private val projectRoomService = mock(ProjectRoomService::class.java)
+    private val userQueryClient = mock(UserQueryClient::class.java)
+    private val outSleepingClient = mock(OutSleepingClient::class.java)
+    private val useCase = NightStudyUseCase(
+        nightStudyService = nightStudyService,
+        nightStudyAttendanceService = nightStudyAttendanceService,
+        projectRoomService = projectRoomService,
+        userQueryClient = userQueryClient,
+        outSleepingClient = outSleepingClient,
+    )
+
+    @Test
+    fun `개인과 프로젝트 심자가 겹쳐도 사용자와 차수별로 한 번만 집계한다`() {
+        val userId = UUID.randomUUID()
+        val personal = nightStudy(id = 1L, type = NightStudyType.PERSONAL, period = 2)
+        val projectRoom = mock(ProjectRoomEntity::class.java)
+        val project = nightStudy(id = 2L, type = NightStudyType.PROJECT, period = 1, room = projectRoom)
+
+        `when`(projectRoom.name).thenReturn("LAB13")
+        `when`(nightStudyService.getAllAllowed()).thenReturn(listOf(personal, project))
+        `when`(nightStudyService.getMembersByNightStudies(listOf(personal, project))).thenReturn(
+            mapOf(
+                1L to listOf(userId),
+                2L to listOf(userId),
+            )
+        )
+        stubUsers(student(userId, grade = 1, room = 1, number = 1))
+
+        val result = useCase.countTotalMembers().data!!
+
+        assertEquals(1, result.total.period1.male)
+        assertEquals(1, result.total.period2.male)
+        assertEquals(0, result.total.period1.female)
+        assertEquals(0, result.total.period2.female)
+        assertEquals(1, result.floors.single { it.floor == 3 }.count.period1.male)
+        assertEquals(1, result.floors.single { it.floor == 2 }.count.period2.male)
+        assertEquals(1, result.grades.single { it.grade == 1 }.count.period1.male)
+        assertEquals(1, result.grades.single { it.grade == 1 }.count.period2.male)
+    }
+
+    private fun nightStudy(
+        id: Long,
+        type: NightStudyType,
+        period: Int,
+        room: ProjectRoomEntity? = null,
+    ): NightStudyEntity = mock(NightStudyEntity::class.java).also { nightStudy ->
+        `when`(nightStudy.id).thenReturn(id)
+        `when`(nightStudy.type).thenReturn(type)
+        `when`(nightStudy.period).thenReturn(period)
+        `when`(nightStudy.room).thenReturn(room)
+    }
+
+    private fun student(
+        userId: UUID,
+        grade: Int,
+        room: Int,
+        number: Int,
+    ): UserResponse = UserResponse.newBuilder()
+        .setPublicId(userId.toString())
+        .setName("학생")
+        .setStudent(
+            StudentInfo.newBuilder()
+                .setGrade(grade)
+                .setRoom(room)
+                .setNumber(number)
+        )
+        .build()
+
+    private fun stubUsers(vararg users: UserResponse) {
+        val response = GetUsersResponse.newBuilder().addAllUsers(users.toList()).build()
+        runBlocking {
+            `when`(userQueryClient.getUsers(anyList())).thenReturn(response)
+        }
+    }
+}


### PR DESCRIPTION
## 변경 내용

- `GET /nightstudy/applications/total`의 인원 집계 기준을 변경했습니다.
- 기존 개인/프로젝트 기준 대신 성별과 심자 차수 기준으로 인원을 반환합니다.
- 층별 집계와 함께 1·2·3학년별 집계를 추가했습니다.
- 동일 학생이 개인 심자와 프로젝트 심자에 중복으로 포함된 경우, 학생·차수별 한 번만 집계하도록 수정했습니다.
- 개인 심자와 프로젝트 심자가 중복되면 프로젝트 심자 위치를 우선 적용합니다.
- 심자 2 신청자는 기존 규칙대로 심자 1과 심자 2에 모두 포함됩니다.
- 현재 사용자 정보에 성별 데이터가 없어 모든 학생을 `male`로 집계하며, `female`은 0으로 반환합니다.

## 관련 이슈

- Resolves #280

## 테스트 방법

- [x] 단위 테스트 추가/수정
- [ ] 통합 테스트 완료
- [ ] 수동 테스트 완료

실행한 테스트:

```shell
./gradlew :services:service-nightstudy:test --no-daemon
```

결과: `BUILD SUCCESSFUL`

## 스크린샷 (UI 변경 시)

서버 응답 및 집계 로직 변경으로 해당 사항이 없습니다.

### Before

해당 없음

### After

해당 없음

## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 완료했습니다
- [x] 변경 사항에 대한 테스트를 추가했습니다
- [x] 문서를 업데이트했습니다 (문서 변경 불필요)
- [ ] Breaking Changes가 없습니다

## 기타 사항

- 기존 `period1/period2` 하위의 `personal`, `project` 필드가 `male`, `female`로 변경되어 API 응답에 Breaking Change가 있습니다.
- 응답에 `grades` 필드가 추가되어 학년별 인원을 함께 제공합니다.
- 프로젝트 심자 승인 시 자동 생성되는 개인 심자로 인해 동일 학생이 중복 집계될 수 있었으며, 이번 변경에서 학생 UUID와 심자 차수를 기준으로 중복을 제거했습니다.
- 성별 정보가 사용자 서비스에 추가되기 전까지 모든 인원은 임시로 `male`에 집계됩니다.