### PR TITLE
Fix: 자동 심자 유형분리

### DIFF
--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/enumeration/NightStudyType.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/enumeration/NightStudyType.kt
@@ -2,5 +2,6 @@ package com.b1nd.dodamdodam.nightstudy.domain.nightstudy.enumeration
 
 enum class NightStudyType {
     PERSONAL,
-    PROJECT
+    PROJECT,
+    AUTO
 }

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyService.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyService.kt
@@ -133,12 +133,12 @@ class NightStudyService(
                 if (hasPersonal) return@forEach
 
                 val nightStudy = NightStudyEntity(
-                        description = "프로젝트 심야자습으로 인한 자동 신청",
+                        description = ns.description,
                         period = if (ns.period == 1) 2 else 1,
-                        type = NightStudyType.PERSONAL,
+                        type = NightStudyType.AUTO,
                         startAt = ns.startAt,
                         endAt = ns.endAt,
-                        status = NightStudyStatusType.ALLOWED,
+                        status = NightStudyStatusType.PENDING,
                         needPhone = false
                 )
 


### PR DESCRIPTION
## 변경 내용

프로젝트 심야자습으로 인한 자동 신청 시 심자 유형을 분리했습니다.

### 상세 변경사항
- `NightStudyType` enum에 `AUTO` 타입 추가
- 자동 신청 시 타입을 `PERSONAL`에서 `AUTO`로 변경
- 상태를 `ALLOWED`에서 `PENDING`으로 변경 (자동 신청이므로 승인 대기 상태)
- 설명을 하드코딩된 문자열 대신 프로젝트 심자의 설명 사용

## 관련 이슈

- Resolves #280

## 테스트 방법

- [x] 자동 심자 생성 로직 확인
- [x] 심자 유형이 올바르게 분리되는지 확인

## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 완료했습니다
- [ ] 변경 사항에 대한 테스트를 추가했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] Breaking Changes가 없습니다