### PR TITLE
Develop

### DIFF
--- a/services/service-inapp/src/main/kotlin/com/b1nd/dodamdodam/inapp/application/app/AppUseCase.kt
+++ b/services/service-inapp/src/main/kotlin/com/b1nd/dodamdodam/inapp/application/app/AppUseCase.kt
@@ -1,5 +1,6 @@
 package com.b1nd.dodamdodam.inapp.application.app
 
+import com.b1nd.dodamdodam.core.common.data.InfinityScrollPageResponse
 import com.b1nd.dodamdodam.inapp.application.app.data.response.PageResponse
 import com.b1nd.dodamdodam.core.common.data.Response
 import com.b1nd.dodamdodam.core.security.passport.holder.PassportHolder
@@ -17,6 +18,7 @@ import com.b1nd.dodamdodam.inapp.application.app.data.response.AppReleaseDetailR
 import com.b1nd.dodamdodam.inapp.application.app.data.response.AppResponse
 import com.b1nd.dodamdodam.inapp.application.app.data.response.AppSummaryResponse
 import com.b1nd.dodamdodam.core.github.client.GitHubClient
+import com.b1nd.dodamdodam.inapp.application.app.data.response.GetAllAppsResponse
 import com.b1nd.dodamdodam.inapp.application.app.data.toActiveAppResponse
 import com.b1nd.dodamdodam.inapp.application.app.data.toCommand
 import com.b1nd.dodamdodam.inapp.application.app.data.toDetailResponse
@@ -124,6 +126,19 @@ class AppUseCase(
     fun deleteApp(appId: UUID): Response<Any> {
         appService.deleteApp(currentUserId(), appId)
         return Response.ok("앱이 삭제되었어요.")
+    }
+
+    @Transactional(readOnly = true)
+    fun getAllApps(pageable: Pageable):Response<InfinityScrollPageResponse<GetAllAppsResponse>> {
+        val apps = appService.getAllApps(pageable)
+
+        return Response.ok(
+            "모든 앱이 조회되었어요.",
+            InfinityScrollPageResponse(
+                content = GetAllAppsResponse.fromList(apps.content),
+                hasNext = apps.hasNext()
+            )
+        )
     }
 
     private fun currentUserId() = PassportHolder.current().requireUserId()

--- a/services/service-inapp/src/main/kotlin/com/b1nd/dodamdodam/inapp/application/app/data/response/GetAllAppsResponse.kt
+++ b/services/service-inapp/src/main/kotlin/com/b1nd/dodamdodam/inapp/application/app/data/response/GetAllAppsResponse.kt
@@ -6,14 +6,16 @@ import java.util.UUID
 data class GetAllAppsResponse(
     val appId: UUID?,
     val name: String,
-    val subtitle: String
+    val subtitle: String,
+    val iconUrl: String
 ) {
     companion object {
         fun of(app: AppEntity) =
             GetAllAppsResponse(
                 appId = app.publicId,
                 name = app.name,
-                subtitle = app.subtitle
+                subtitle = app.subtitle,
+                iconUrl = app.iconUrl
             )
 
         fun fromList(apps: List<AppEntity>): List<GetAllAppsResponse> {

--- a/services/service-inapp/src/main/kotlin/com/b1nd/dodamdodam/inapp/application/app/data/response/GetAllAppsResponse.kt
+++ b/services/service-inapp/src/main/kotlin/com/b1nd/dodamdodam/inapp/application/app/data/response/GetAllAppsResponse.kt
@@ -1,0 +1,23 @@
+package com.b1nd.dodamdodam.inapp.application.app.data.response
+
+import com.b1nd.dodamdodam.inapp.domain.app.entity.AppEntity
+import java.util.UUID
+
+data class GetAllAppsResponse(
+    val appId: UUID?,
+    val name: String,
+    val subtitle: String
+) {
+    companion object {
+        fun of(app: AppEntity) =
+            GetAllAppsResponse(
+                appId = app.publicId,
+                name = app.name,
+                subtitle = app.subtitle
+            )
+
+        fun fromList(apps: List<AppEntity>): List<GetAllAppsResponse> {
+            return apps.map { of(it) }
+        }
+    }
+}

--- a/services/service-inapp/src/main/kotlin/com/b1nd/dodamdodam/inapp/domain/app/service/AppService.kt
+++ b/services/service-inapp/src/main/kotlin/com/b1nd/dodamdodam/inapp/domain/app/service/AppService.kt
@@ -158,6 +158,9 @@ class AppService(
         appReleaseRepository.findByPublicId(releaseId)
             ?: throw AppReleaseNotFoundException()
 
+    fun getAllApps(pageable: Pageable) =
+        appRepository.findAll(pageable)
+
     private fun validateAppOwner(userId: UUID, app: AppEntity) {
         if (!teamMemberRepository.existsByUserAndTeamAndIsOwnerIsTrue(userId, app.team)) {
             throw AppTeamOwnerPermissionRequiredException()

--- a/services/service-inapp/src/main/kotlin/com/b1nd/dodamdodam/inapp/presentation/app/AppController.kt
+++ b/services/service-inapp/src/main/kotlin/com/b1nd/dodamdodam/inapp/presentation/app/AppController.kt
@@ -95,4 +95,9 @@ class AppController(
         @RequestParam(required = false) keyword: String?,
         pageable: Pageable,
     ) = appUseCase.getReleases(appId, date, keyword, pageable)
+
+    @UserAccess(roles = [RoleType.ADMIN])
+    @GetMapping
+    fun getApps(pageable: Pageable) =
+        appUseCase.getAllApps(pageable)
 }

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/NightStudyUseCase.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/NightStudyUseCase.kt
@@ -138,8 +138,8 @@ class NightStudyUseCase(
                 personal = byType.getValue(NightStudyType.PERSONAL),
                 project = byType.getValue(NightStudyType.PROJECT),
                 total = NightStudyApprovedCountResponse.PeriodCount(
-                    period1 = byType.values.sumOf { it.period1 },
-                    period2 = byType.values.sumOf { it.period2 },
+                    period1 = byType.values.sumOf { it.period1 } - byType.getValue(NightStudyType.AUTO).period1,
+                    period2 = byType.values.sumOf { it.period2 } - byType.getValue(NightStudyType.AUTO).period2,
                 ),
             ),
         )

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/NightStudyUseCase.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/NightStudyUseCase.kt
@@ -177,9 +177,9 @@ class NightStudyUseCase(
     }
 
     fun countTotalMembers(): Response<NightStudyTotalCountResponse> {
-        val nightStudys = nightStudyService.getAllAllowed()
+        val nightStudies = nightStudyService.getAllAllowed()
 
-        val membersByNightStudy = nightStudyService.getMembersByNightStudies(nightStudys)
+        val membersByNightStudy = nightStudyService.getMembersByNightStudies(nightStudies)
         val userIds = membersByNightStudy.values.flatten()
             .map { it.toString() }
             .distinct()
@@ -187,21 +187,50 @@ class NightStudyUseCase(
         val userById = runBlocking { userQueryClient.getUsers(userIds) }.usersList
             .associateBy { it.publicId }
 
-        val counts = nightStudys.flatMap { nightStudy ->
+        val members = nightStudies.flatMap { nightStudy ->
             val memberIds = membersByNightStudy[nightStudy.id] ?: emptyList()
 
-            memberIds.map { memberId ->
-                val user = userById[memberId.toString()]
-                Triple(
-                    resolveFloor(nightStudy, user),
-                    nightStudy.type,
-                    nightStudy.period,
+            memberIds.flatMap { memberId ->
+                periodsIncludedBy(nightStudy.period).map { period ->
+                    CountCandidate(memberId, period, nightStudy)
+                }
+            }
+        }.groupBy { it.userId to it.period }
+            .mapNotNull { (_, candidates) ->
+                val selected = candidates.maxWithOrNull(
+                    compareBy<CountCandidate>(
+                        { it.nightStudy.type == NightStudyType.PROJECT },
+                        { it.nightStudy.period == it.period },
+                    )
+                ) ?: return@mapNotNull null
+                val user = userById[selected.userId.toString()]
+                    ?.takeIf { it.hasStudent() }
+                    ?: return@mapNotNull null
+                val grade = user.student.grade.takeIf { it in 1..3 }
+                    ?: return@mapNotNull null
+
+                NightStudyTotalCountResponse.MemberCount(
+                    floor = resolveFloor(selected.nightStudy, user),
+                    grade = grade,
+                    period = selected.period,
+                    gender = NightStudyTotalCountResponse.Gender.MALE,
                 )
             }
-        }.groupingBy { it }.eachCount()
 
-        return Response.ok("심자 층별 인원수를 조회했어요.", NightStudyTotalCountResponse.of(counts))
+        return Response.ok("심자 인원수를 조회했어요.", NightStudyTotalCountResponse.of(members))
     }
+
+    private fun periodsIncludedBy(period: Int): List<Int> = when (period) {
+        1 -> listOf(1)
+        2 -> listOf(1, 2)
+        else -> emptyList()
+    }
+
+    private data class CountCandidate(
+        val userId: UUID,
+        val period: Int,
+        val nightStudy: NightStudyEntity,
+    )
 
     private fun resolveFloor(nightStudy: NightStudyEntity, user: UserResponse?): Int =
         if (nightStudy.type == NightStudyType.PROJECT) {

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/NightStudyUseCase.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/NightStudyUseCase.kt
@@ -94,11 +94,21 @@ class NightStudyUseCase(
         val usersMap = fetchUsersMap(visibleNightStudies)
         val projectMemberNightStudyIds = nightStudyService.getProjectMemberNightStudyIds(allNightStudies)
 
-        val sorted = visibleNightStudies.sortedWith(compareBy(
-            { usersMap[it.leaderId?.toString()]?.student?.grade ?: Int.MAX_VALUE },
-            { usersMap[it.leaderId?.toString()]?.student?.room ?: Int.MAX_VALUE },
-            { usersMap[it.leaderId?.toString()]?.student?.number ?: Int.MAX_VALUE }
-        ))
+        val sorted = if (type == NightStudyType.PROJECT) {
+            visibleNightStudies.sortedWith(
+                compareBy<NightStudyWithMembersCommand> {
+                    it.nightStudy.createdAt ?: LocalDateTime.MAX
+                }.thenBy {
+                    it.nightStudy.id ?: Long.MAX_VALUE
+                }
+            )
+        } else {
+            visibleNightStudies.sortedWith(compareBy(
+                { usersMap[it.leaderId?.toString()]?.student?.grade ?: Int.MAX_VALUE },
+                { usersMap[it.leaderId?.toString()]?.student?.room ?: Int.MAX_VALUE },
+                { usersMap[it.leaderId?.toString()]?.student?.number ?: Int.MAX_VALUE }
+            ))
+        }
 
         val offset = pageable.offset.toInt()
         val pageSize = pageable.pageSize

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/NightStudyUseCase.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/NightStudyUseCase.kt
@@ -29,6 +29,7 @@ import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.ZoneId
 import java.util.*
 
 @Component
@@ -333,7 +334,7 @@ class NightStudyUseCase(
 
     private fun validateApplicationAvailability(stratAt: LocalDate, period: Int) {
         val now = LocalDateTime.now()
-        val deadline = LocalDate.now().atTime(20, 30)
+        val deadline = LocalDate.now(ZoneId.of("Asia/Seoul")).atTime(20, 30)
         if (now.isAfter(deadline))
             throw BasicException(NightStudyExceptionCode.NOT_APPLICATION_TIME)
         if (stratAt.isBefore(now.toLocalDate()))

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/data/response/NightStudyTotalCountResponse.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/data/response/NightStudyTotalCountResponse.kt
@@ -1,9 +1,8 @@
 package com.b1nd.dodamdodam.nightstudy.application.nightstudy.data.response
 
-import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.enumeration.NightStudyType
-
 data class NightStudyTotalCountResponse(
     val floors: List<FloorCount>,
+    val grades: List<GradeCount>,
     val total: PeriodCount,
 ) {
     data class FloorCount(
@@ -11,42 +10,63 @@ data class NightStudyTotalCountResponse(
         val count: PeriodCount,
     )
 
-    data class PeriodCount(
-        val period1: TypeCount,
-        val period2: TypeCount,
+    data class GradeCount(
+        val grade: Int,
+        val count: PeriodCount,
     )
 
-    data class TypeCount(
-        val personal: Int,
-        val project: Int,
+    data class PeriodCount(
+        val period1: GenderCount,
+        val period2: GenderCount,
     )
+
+    data class GenderCount(
+        val male: Int,
+        val female: Int,
+    )
+
+    data class MemberCount(
+        val floor: Int,
+        val grade: Int,
+        val period: Int,
+        val gender: Gender,
+    )
+
+    enum class Gender {
+        MALE,
+        FEMALE,
+    }
 
     companion object {
-        fun of(count: Map<Triple<Int, NightStudyType, Int>, Int>): NightStudyTotalCountResponse {
-            fun typeCount(floor: Int, vararg periods: Int) = TypeCount(
-                personal = periods.sumOf { count[Triple(floor, NightStudyType.PERSONAL, it)] ?: 0 },
-                project = periods.sumOf { count[Triple(floor, NightStudyType.PROJECT, it)] ?: 0 },
+        fun of(members: List<MemberCount>): NightStudyTotalCountResponse {
+            fun genderCount(filtered: List<MemberCount>, period: Int) = GenderCount(
+                male = filtered.count { it.period == period && it.gender == Gender.MALE },
+                female = filtered.count { it.period == period && it.gender == Gender.FEMALE },
             )
-            fun periodCount(floor: Int) = PeriodCount(
-                period1 = typeCount(floor, 1, 2),
-                period2 = typeCount(floor, 2),
+
+            fun periodCount(filtered: List<MemberCount>) = PeriodCount(
+                period1 = genderCount(filtered, 1),
+                period2 = genderCount(filtered, 2),
             )
 
             val floors = listOf(2, 3).map { floor ->
-                FloorCount(floor = floor, count = periodCount(floor))
+                FloorCount(
+                    floor = floor,
+                    count = periodCount(members.filter { it.floor == floor }),
+                )
             }
-            val total = PeriodCount(
-                period1 = TypeCount(
-                    personal = floors.sumOf { it.count.period1.personal },
-                    project = floors.sumOf { it.count.period1.project },
-                ),
-                period2 = TypeCount(
-                    personal = floors.sumOf { it.count.period2.personal },
-                    project = floors.sumOf { it.count.period2.project },
-                ),
-            )
+            val grades = (1..3).map { grade ->
+                GradeCount(
+                    grade = grade,
+                    count = periodCount(members.filter { it.grade == grade }),
+                )
+            }
 
-            return NightStudyTotalCountResponse(floors = floors, total = total)
+            return NightStudyTotalCountResponse(
+                floors = floors,
+                grades = grades,
+                total = periodCount(members),
+            )
         }
     }
 }

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/room/ProjectRoomUseCase.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/room/ProjectRoomUseCase.kt
@@ -93,7 +93,7 @@ class ProjectRoomUseCase(
         val validRoomIds = rooms.map { it.id }.toSet()
         val assignments = nightStudyService.getAllowedRoomMembers(date, period)
             .groupBy { it.userId }
-            .mapValues { (_, values) -> selectAssignment(values) }
+            .mapValues { (_, values) -> selectAssignment(values, period) }
         val attendedUserIds = nightStudyAttendanceService.getAttendedUserIds(assignments.keys, date, period)
         val users = if (assignments.isEmpty()) {
             emptyList()
@@ -143,11 +143,16 @@ class ProjectRoomUseCase(
         return classRooms + thirdGradeRoom + projectRooms
     }
 
-    private fun selectAssignment(assignments: List<NightStudyRoomMemberCommand>): NightStudyRoomMemberCommand {
-        return assignments.firstOrNull {
+    private fun selectAssignment(
+        assignments: List<NightStudyRoomMemberCommand>,
+        period: Int,
+    ): NightStudyRoomMemberCommand {
+        val periodAssignments = assignments.filter { it.period == period }.ifEmpty { assignments }
+
+        return periodAssignments.firstOrNull {
             it.type == NightStudyType.PROJECT && it.projectRoomId != null
-        } ?: assignments.firstOrNull { it.type == NightStudyType.PERSONAL }
-        ?: assignments.first()
+        } ?: periodAssignments.firstOrNull { it.type == NightStudyType.PERSONAL }
+        ?: periodAssignments.first()
     }
 
     private fun resolveRoomId(assignment: NightStudyRoomMemberCommand, grade: Int, room: Int): String? {

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/command/NightStudyRoomMemberCommand.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/command/NightStudyRoomMemberCommand.kt
@@ -6,5 +6,6 @@ import java.util.UUID
 data class NightStudyRoomMemberCommand(
     val userId: UUID,
     val type: NightStudyType,
+    val period: Int,
     val projectRoomId: Long?,
 )

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/enumeration/NightStudyType.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/enumeration/NightStudyType.kt
@@ -2,5 +2,6 @@ package com.b1nd.dodamdodam.nightstudy.domain.nightstudy.enumeration
 
 enum class NightStudyType {
     PERSONAL,
-    PROJECT
+    PROJECT,
+    AUTO
 }

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepositoryImpl.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepositoryImpl.kt
@@ -183,6 +183,7 @@ class NightStudyQueryRepositoryImpl(
             .select(
                 nightStudyMemberEntity.userId,
                 nightStudyEntity.type,
+                nightStudyEntity.period,
                 projectRoom.id,
             )
             .from(nightStudyMemberEntity)
@@ -200,6 +201,7 @@ class NightStudyQueryRepositoryImpl(
                 NightStudyRoomMemberCommand(
                     userId = tuple.get(nightStudyMemberEntity.userId)!!,
                     type = tuple.get(nightStudyEntity.type)!!,
+                    period = tuple.get(nightStudyEntity.period)!!,
                     projectRoomId = tuple.get(projectRoom.id),
                 )
             }

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyService.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyService.kt
@@ -133,12 +133,12 @@ class NightStudyService(
                 if (hasPersonal) return@forEach
 
                 val nightStudy = NightStudyEntity(
-                        description = "프로젝트 심야자습으로 인한 자동 신청",
+                        description = ns.description,
                         period = if (ns.period == 1) 2 else 1,
-                        type = NightStudyType.PERSONAL,
+                        type = NightStudyType.AUTO,
                         startAt = ns.startAt,
                         endAt = ns.endAt,
-                        status = NightStudyStatusType.ALLOWED,
+                        status = NightStudyStatusType.PENDING,
                         needPhone = false
                 )
 

--- a/services/service-nightstudy/src/test/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/NightStudyUseCaseCountTest.kt
+++ b/services/service-nightstudy/src/test/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/NightStudyUseCaseCountTest.kt
@@ -1,0 +1,99 @@
+package com.b1nd.dodamdodam.nightstudy.application.nightstudy
+
+import com.b1nd.dodamdodam.grpc.user.GetUsersResponse
+import com.b1nd.dodamdodam.grpc.user.StudentInfo
+import com.b1nd.dodamdodam.grpc.user.UserResponse
+import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.entity.NightStudyEntity
+import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.enumeration.NightStudyType
+import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.service.NightStudyAttendanceService
+import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.service.NightStudyService
+import com.b1nd.dodamdodam.nightstudy.domain.room.entity.ProjectRoomEntity
+import com.b1nd.dodamdodam.nightstudy.domain.room.service.ProjectRoomService
+import com.b1nd.dodamdodam.nightstudy.infrastructure.outSleeping.client.OutSleepingClient
+import com.b1nd.dodamdodam.nightstudy.infrastructure.user.client.UserQueryClient
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.anyList
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
+import java.util.UUID
+
+class NightStudyUseCaseCountTest {
+    private val nightStudyService = mock(NightStudyService::class.java)
+    private val nightStudyAttendanceService = mock(NightStudyAttendanceService::class.java)
+    private val projectRoomService = mock(ProjectRoomService::class.java)
+    private val userQueryClient = mock(UserQueryClient::class.java)
+    private val outSleepingClient = mock(OutSleepingClient::class.java)
+    private val useCase = NightStudyUseCase(
+        nightStudyService = nightStudyService,
+        nightStudyAttendanceService = nightStudyAttendanceService,
+        projectRoomService = projectRoomService,
+        userQueryClient = userQueryClient,
+        outSleepingClient = outSleepingClient,
+    )
+
+    @Test
+    fun `개인과 프로젝트 심자가 겹쳐도 사용자와 차수별로 한 번만 집계한다`() {
+        val userId = UUID.randomUUID()
+        val personal = nightStudy(id = 1L, type = NightStudyType.PERSONAL, period = 2)
+        val projectRoom = mock(ProjectRoomEntity::class.java)
+        val project = nightStudy(id = 2L, type = NightStudyType.PROJECT, period = 1, room = projectRoom)
+
+        `when`(projectRoom.name).thenReturn("LAB13")
+        `when`(nightStudyService.getAllAllowed()).thenReturn(listOf(personal, project))
+        `when`(nightStudyService.getMembersByNightStudies(listOf(personal, project))).thenReturn(
+            mapOf(
+                1L to listOf(userId),
+                2L to listOf(userId),
+            )
+        )
+        stubUsers(student(userId, grade = 1, room = 1, number = 1))
+
+        val result = useCase.countTotalMembers().data!!
+
+        assertEquals(1, result.total.period1.male)
+        assertEquals(1, result.total.period2.male)
+        assertEquals(0, result.total.period1.female)
+        assertEquals(0, result.total.period2.female)
+        assertEquals(1, result.floors.single { it.floor == 3 }.count.period1.male)
+        assertEquals(1, result.floors.single { it.floor == 2 }.count.period2.male)
+        assertEquals(1, result.grades.single { it.grade == 1 }.count.period1.male)
+        assertEquals(1, result.grades.single { it.grade == 1 }.count.period2.male)
+    }
+
+    private fun nightStudy(
+        id: Long,
+        type: NightStudyType,
+        period: Int,
+        room: ProjectRoomEntity? = null,
+    ): NightStudyEntity = mock(NightStudyEntity::class.java).also { nightStudy ->
+        `when`(nightStudy.id).thenReturn(id)
+        `when`(nightStudy.type).thenReturn(type)
+        `when`(nightStudy.period).thenReturn(period)
+        `when`(nightStudy.room).thenReturn(room)
+    }
+
+    private fun student(
+        userId: UUID,
+        grade: Int,
+        room: Int,
+        number: Int,
+    ): UserResponse = UserResponse.newBuilder()
+        .setPublicId(userId.toString())
+        .setName("학생")
+        .setStudent(
+            StudentInfo.newBuilder()
+                .setGrade(grade)
+                .setRoom(room)
+                .setNumber(number)
+        )
+        .build()
+
+    private fun stubUsers(vararg users: UserResponse) {
+        val response = GetUsersResponse.newBuilder().addAllUsers(users.toList()).build()
+        runBlocking {
+            `when`(userQueryClient.getUsers(anyList())).thenReturn(response)
+        }
+    }
+}

--- a/services/service-nightstudy/src/test/kotlin/com/b1nd/dodamdodam/nightstudy/application/room/ProjectRoomUseCaseTest.kt
+++ b/services/service-nightstudy/src/test/kotlin/com/b1nd/dodamdodam/nightstudy/application/room/ProjectRoomUseCaseTest.kt
@@ -37,8 +37,8 @@ class ProjectRoomUseCaseTest {
         val firstUserId = UUID.randomUUID()
         val secondUserId = UUID.randomUUID()
         val assignments = listOf(
-            personalAssignment(firstUserId),
-            personalAssignment(secondUserId),
+            personalAssignment(firstUserId, period = 1),
+            personalAssignment(secondUserId, period = 1),
         )
 
         `when`(projectRoomService.getAll()).thenReturn(emptyList())
@@ -63,8 +63,8 @@ class ProjectRoomUseCaseTest {
         val userId = UUID.randomUUID()
         val projectRoom = mock(ProjectRoomEntity::class.java)
         val assignments = listOf(
-            personalAssignment(userId),
-            NightStudyRoomMemberCommand(userId, NightStudyType.PROJECT, projectRoomId = 12L),
+            personalAssignment(userId, period = 2),
+            projectAssignment(userId, period = 2, projectRoomId = 12L),
         )
 
         `when`(projectRoom.id).thenReturn(12L)
@@ -83,10 +83,71 @@ class ProjectRoomUseCaseTest {
         assertEquals(0, classRoom.memberCount)
     }
 
-    private fun personalAssignment(userId: UUID) = NightStudyRoomMemberCommand(
+    @Test
+    fun `심1 개인 심자와 심2 프로젝트 심자가 있으면 심1에는 개인 심자실로 배정한다`() {
+        val date = LocalDate.of(2026, 8, 13)
+        val userId = UUID.randomUUID()
+        val projectRoom = mock(ProjectRoomEntity::class.java)
+        val assignments = listOf(
+            projectAssignment(userId, period = 2, projectRoomId = 13L),
+            personalAssignment(userId, period = 1),
+        )
+
+        `when`(projectRoom.id).thenReturn(13L)
+        `when`(projectRoom.name).thenReturn("LAB 13")
+        `when`(projectRoomService.getAll()).thenReturn(listOf(projectRoom))
+        `when`(nightStudyService.getAllowedRoomMembers(date, 1)).thenReturn(assignments)
+        `when`(attendanceService.getAttendedUserIds(setOf(userId), date, 1)).thenReturn(emptySet())
+        stubUsers(student(userId, "프로젝트 학생", grade = 1, room = 2, number = 1))
+
+        val response = useCase.getAllWithStatus(date, 1)
+        val project = response.data!!.single { it.roomId == "PROJECT_13" }
+        val classRoom = response.data!!.single { it.roomId == "CLASS_1_2" }
+
+        assertEquals(0, project.memberCount)
+        assertEquals(1, classRoom.memberCount)
+    }
+
+    @Test
+    fun `심1과 심2 프로젝트실이 다르면 요청 교시 프로젝트실로 배정한다`() {
+        val date = LocalDate.of(2026, 8, 13)
+        val userId = UUID.randomUUID()
+        val firstPeriodRoom = mock(ProjectRoomEntity::class.java)
+        val secondPeriodRoom = mock(ProjectRoomEntity::class.java)
+        val assignments = listOf(
+            projectAssignment(userId, period = 2, projectRoomId = 13L),
+            projectAssignment(userId, period = 1, projectRoomId = 1L),
+        )
+
+        `when`(firstPeriodRoom.id).thenReturn(1L)
+        `when`(firstPeriodRoom.name).thenReturn("LAB 1")
+        `when`(secondPeriodRoom.id).thenReturn(13L)
+        `when`(secondPeriodRoom.name).thenReturn("LAB 13")
+        `when`(projectRoomService.getAll()).thenReturn(listOf(firstPeriodRoom, secondPeriodRoom))
+        `when`(nightStudyService.getAllowedRoomMembers(date, 1)).thenReturn(assignments)
+        `when`(attendanceService.getAttendedUserIds(setOf(userId), date, 1)).thenReturn(emptySet())
+        stubUsers(student(userId, "프로젝트 학생", grade = 1, room = 1, number = 1))
+
+        val response = useCase.getAllWithStatus(date, 1)
+        val firstPeriodProject = response.data!!.single { it.roomId == "PROJECT_1" }
+        val secondPeriodProject = response.data!!.single { it.roomId == "PROJECT_13" }
+
+        assertEquals(1, firstPeriodProject.memberCount)
+        assertEquals(0, secondPeriodProject.memberCount)
+    }
+
+    private fun personalAssignment(userId: UUID, period: Int) = NightStudyRoomMemberCommand(
         userId = userId,
         type = NightStudyType.PERSONAL,
+        period = period,
         projectRoomId = null,
+    )
+
+    private fun projectAssignment(userId: UUID, period: Int, projectRoomId: Long) = NightStudyRoomMemberCommand(
+        userId = userId,
+        type = NightStudyType.PROJECT,
+        period = period,
+        projectRoomId = projectRoomId,
     )
 
     private fun student(


### PR DESCRIPTION
## 변경 내용

`develop` 브랜치에 누적된 In-App 및 심야자습 관련 변경사항을 `main` 브랜치에 반영합니다.

### In-App

- 관리자용 전체 앱 조회 API를 추가했습니다.
- 전체 앱 조회 응답에 앱 ID, 이름, 부제목 및 아이콘 URL을 포함하도록 구성했습니다.
- 페이지네이션 및 다음 페이지 존재 여부를 반환하도록 구성했습니다.

### 심야자습

- 프로젝트 심자 신청 목록을 신청 생성 시간순으로 정렬하도록 변경했습니다.
- 심자 인원 조회 응답을 층별·학년별·성별 집계 구조로 변경했습니다.
- 개인 심자와 프로젝트 심자가 중복되는 경우 학생·교시별로 한 번만 집계하도록 수정했습니다.
- 프로젝트 심자로 인해 생성되는 자동 신청을 `AUTO` 유형으로 분리했습니다.
- 자동 신청을 승인 대기 상태로 생성하고 프로젝트 심자의 설명을 사용하도록 변경했습니다.
- 심자 인원 카운트에서 `AUTO` 유형을 제외하도록 수정했습니다.
- 심야자습 신청 마감 시간 계산에 `Asia/Seoul` 타임존을 적용했습니다.
- 출석체크 랩실 조회 시 요청 교시와 동일한 방 배정을 우선하도록 수정했습니다.
- 심1·심2 프로젝트실이 서로 다른 경우 인원이 잘못된 랩실에 표시되던 문제를 수정했습니다.
- 심2 신청자를 심1 출석 대상에 포함하는 기존 누적 출석 정책은 유지했습니다.

## 관련 이슈

- Resolves #278
- Resolves #280
- Resolves #284
- Resolves #286
- Resolves #289
- Resolves #291

## 포함된 PR

- #279 프로젝트 심자 신청 목록 정렬
- #281 심자 인원 조회 집계 기준 변경
- #283 자동 심자 유형 분리
- #285 전체 앱 조회 API 추가
- #287 심야자습 신청 마감 시간 타임존 설정
- #290 심자 인원 카운트에서 AUTO 제외
- #292 교시별 프로젝트실 조회 수정

## 테스트 방법

- [x] 단위 테스트 추가/수정
- [ ] 통합 테스트 완료
- [x] 수동 테스트 완료

개별 PR에서 다음 항목을 검증했습니다.

- `./gradlew :services:service-nightstudy:test --no-daemon` 실행
- 심자 인원 중복 집계 방지 테스트
- 심1 개인 심자·심2 프로젝트 심자 조합 테스트
- 심1·심2 프로젝트실이 서로 다른 조합 테스트
- 전체 앱 조회 API 수동 테스트
- 심야자습 신청 마감 시간 타임존 수동 테스트
- 심자 인원 카운트의 `AUTO` 제외 여부 수동 테스트

## 스크린샷 (UI 변경 시)

서버 API 및 비즈니스 로직 변경으로 해당 사항이 없습니다.

## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 완료했습니다
- [x] 변경 사항에 대한 테스트를 추가했습니다
- [x] 문서를 업데이트했습니다 (변경 필요 없음)
- [ ] Breaking Changes가 없습니다

## 기타 사항

### Breaking Change

`GET /nightstudy/applications/total` 응답 구조가 변경됩니다.

- 기존 `personal`, `project` 기준 집계가 `male`, `female` 기준으로 변경됩니다.
- 학년별 집계를 제공하는 `grades` 필드가 추가됩니다.
- 현재 사용자 정보에 성별 데이터가 없어 모든 학생을 임시로 `male`에 집계합니다.

클라이언트에서 기존 심자 인원 조회 응답 구조를 사용하고 있다면 배포 전 대응이 필요합니다.