### PR TITLE
hotfix: 프로젝트 심자 승인 시 AUTO 중복 방지 (#298)

### DIFF
--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyService.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyService.kt
@@ -125,21 +125,25 @@ class NightStudyService(
         val wasAlreadyAllowed = ns.status == NightStudyStatusType.ALLOWED
         ns.allow()
         if (ns.type == NightStudyType.PROJECT && !wasAlreadyAllowed) {
-            val memberIds = nightStudyMemberQueryRepository.findAllUserIdsByNightStudy(ns)
+            val autoPeriod = if (ns.period == 1) 2 else 1
+            val memberIds = nightStudyMemberQueryRepository.findAllUserIdsByNightStudy(ns).distinct()
             memberIds.forEach { memberId ->
                 val hasPersonal = nightStudyQueryRepository.existsByUserIdAndPeriodOverlap(
-                     memberId, 2, NightStudyType.PERSONAL, ns.startAt, ns.endAt
+                    memberId, autoPeriod, NightStudyType.PERSONAL, ns.startAt, ns.endAt
                 )
-                if (hasPersonal) return@forEach
+                val hasAuto = nightStudyQueryRepository.existsByUserIdAndPeriodOverlap(
+                    memberId, autoPeriod, NightStudyType.AUTO, ns.startAt, ns.endAt
+                )
+                if (hasPersonal || hasAuto) return@forEach
 
                 val nightStudy = NightStudyEntity(
-                        description = ns.description,
-                        period = if (ns.period == 1) 2 else 1,
-                        type = NightStudyType.AUTO,
-                        startAt = ns.startAt,
-                        endAt = ns.endAt,
-                        status = NightStudyStatusType.PENDING,
-                        needPhone = false
+                    description = ns.description,
+                    period = autoPeriod,
+                    type = NightStudyType.AUTO,
+                    startAt = ns.startAt,
+                    endAt = ns.endAt,
+                    status = NightStudyStatusType.PENDING,
+                    needPhone = false
                 )
 
                 save(nightStudy, memberId, null)

--- a/services/service-nightstudy/src/test/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyServiceTest.kt
+++ b/services/service-nightstudy/src/test/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyServiceTest.kt
@@ -1,0 +1,114 @@
+package com.b1nd.dodamdodam.nightstudy.domain.nightstudy.service
+
+import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.entity.NightStudyEntity
+import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.enumeration.NightStudyStatusType
+import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.enumeration.NightStudyType
+import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.repository.nightStudy.NightStudyBannedRepository
+import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.repository.nightStudy.NightStudyQueryRepository
+import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.repository.nightStudy.NightStudyRepository
+import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.repository.nightStudyMember.NightStudyMemberQueryRepository
+import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.repository.nightStudyMember.NightStudyMemberRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import java.time.LocalDate
+import java.util.UUID
+
+class NightStudyServiceTest {
+    private val nightStudyRepository = mock(NightStudyRepository::class.java)
+    private val nightStudyQueryRepository = mock(NightStudyQueryRepository::class.java)
+    private val nightStudyMemberRepository = mock(NightStudyMemberRepository::class.java)
+    private val nightStudyMemberQueryRepository = mock(NightStudyMemberQueryRepository::class.java)
+    private val bannedRepository = mock(NightStudyBannedRepository::class.java)
+    private val service = NightStudyService(
+        nightStudyRepository = nightStudyRepository,
+        nightStudyQueryRepository = nightStudyQueryRepository,
+        nightStudyMemberRepository = nightStudyMemberRepository,
+        nightStudyMemberQueryRepository = nightStudyMemberQueryRepository,
+        bannedRepository = bannedRepository,
+    )
+
+    @Test
+    fun `프로젝트 재승인 시 기존 자동 심자가 있으면 중복 생성하지 않는다`() {
+        val publicId = UUID.randomUUID()
+        val memberId = UUID.randomUUID()
+        val project = projectNightStudy(period = 1)
+        `when`(nightStudyQueryRepository.findByPublicId(publicId)).thenReturn(project)
+        `when`(nightStudyMemberQueryRepository.findAllUserIdsByNightStudy(project))
+            .thenReturn(listOf(memberId, memberId))
+        `when`(
+            nightStudyQueryRepository.existsByUserIdAndPeriodOverlap(
+                memberId,
+                2,
+                NightStudyType.PERSONAL,
+                project.startAt,
+                project.endAt,
+            )
+        ).thenReturn(false)
+        `when`(
+            nightStudyQueryRepository.existsByUserIdAndPeriodOverlap(
+                memberId,
+                2,
+                NightStudyType.AUTO,
+                project.startAt,
+                project.endAt,
+            )
+        ).thenReturn(true)
+
+        service.allow(publicId)
+
+        assertEquals(NightStudyStatusType.ALLOWED, project.status)
+        verify(nightStudyQueryRepository, times(1)).existsByUserIdAndPeriodOverlap(
+            memberId,
+            2,
+            NightStudyType.AUTO,
+            project.startAt,
+            project.endAt,
+        )
+        verify(nightStudyRepository, never()).save(org.mockito.ArgumentMatchers.any())
+    }
+
+    @Test
+    fun `프로젝트 2차 승인 시 자동 심자의 1차 개인 신청 여부를 검사한다`() {
+        val publicId = UUID.randomUUID()
+        val memberId = UUID.randomUUID()
+        val project = projectNightStudy(period = 2)
+        `when`(nightStudyQueryRepository.findByPublicId(publicId)).thenReturn(project)
+        `when`(nightStudyMemberQueryRepository.findAllUserIdsByNightStudy(project)).thenReturn(listOf(memberId))
+        `when`(
+            nightStudyQueryRepository.existsByUserIdAndPeriodOverlap(
+                memberId,
+                1,
+                NightStudyType.PERSONAL,
+                project.startAt,
+                project.endAt,
+            )
+        ).thenReturn(true)
+
+        service.allow(publicId)
+
+        assertEquals(NightStudyStatusType.ALLOWED, project.status)
+        verify(nightStudyQueryRepository).existsByUserIdAndPeriodOverlap(
+            memberId,
+            1,
+            NightStudyType.PERSONAL,
+            project.startAt,
+            project.endAt,
+        )
+        verify(nightStudyRepository, never()).save(org.mockito.ArgumentMatchers.any())
+    }
+
+    private fun projectNightStudy(period: Int) = NightStudyEntity(
+        name = "프로젝트",
+        description = "프로젝트 심자",
+        period = period,
+        startAt = LocalDate.of(2026, 8, 18),
+        endAt = LocalDate.of(2026, 8, 21),
+        needPhone = false,
+        type = NightStudyType.PROJECT,
+    )
+}


### PR DESCRIPTION
## 변경 내용

- 프로젝트 심자 승인 시 생성되는 자동 심자의 차수를 `autoPeriod`로 계산하도록 수정했습니다.
  - 프로젝트 심자 1차 → AUTO 심자 2차
  - 프로젝트 심자 2차 → AUTO 심자 1차
- 같은 사용자에게 동일 기간·차수의 `PERSONAL` 또는 `AUTO` 심자가 이미 존재하면 AUTO 심자를 중복 생성하지 않도록 수정했습니다.
- 프로젝트 멤버 목록에 동일 사용자가 중복되어 있어도 한 번만 처리하도록 `distinct()`를 적용했습니다.
- 프로젝트 심자 재승인 및 반대 차수 검사에 대한 단위 테스트를 추가했습니다.

## 관련 이슈

- Resolves #298
- See also #282

## 테스트 방법

- [x] 단위 테스트 추가/수정
- [x] `service-nightstudy` 전체 테스트 완료
- [ ] 수동 테스트 완료

실행한 테스트:

`./gradlew :services:service-nightstudy:test`

테스트 결과:

`BUILD SUCCESSFUL`

## 스크린샷 (UI 변경 시)

UI 변경 사항이 없어 생략합니다.

## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 완료했습니다
- [x] 변경 사항에 대한 테스트를 추가했습니다
- [x] 문서 업데이트가 필요하지 않은 변경 사항입니다
- [x] Breaking Changes가 없습니다

## 기타 사항

기존 로직에서는 프로젝트 심자를 다시 승인할 때 이전 승인 과정에서 생성된 `AUTO/PENDING` 심자가 남아 있으면 `PeriodOverlappedException`이 발생했습니다. 이 예외로 인해 프로젝트 승인 트랜잭션 전체가 롤백되는 문제가 있었습니다.

이번 변경에서는 기존 `PERSONAL` 또는 `AUTO` 신청이 있으면 자동 신청 생성을 건너뜁니다. 개인·프로젝트 심자 사이의 최종 승인 충돌 정책은 이번 수정 범위에 포함하지 않았습니다.