### PR TITLE
feat: 앱 노출여부 api 접근 권한 추가

### DIFF
--- a/services/service-inapp/src/main/kotlin/com/b1nd/dodamdodam/inapp/application/app/AppUseCase.kt
+++ b/services/service-inapp/src/main/kotlin/com/b1nd/dodamdodam/inapp/application/app/AppUseCase.kt
@@ -18,6 +18,8 @@ import com.b1nd.dodamdodam.inapp.application.app.data.response.AppReleaseDetailR
 import com.b1nd.dodamdodam.inapp.application.app.data.response.AppResponse
 import com.b1nd.dodamdodam.inapp.application.app.data.response.AppSummaryResponse
 import com.b1nd.dodamdodam.core.github.client.GitHubClient
+import com.b1nd.dodamdodam.core.security.exception.AccessDeniedException
+import com.b1nd.dodamdodam.core.security.passport.enumerations.RoleType
 import com.b1nd.dodamdodam.inapp.application.app.data.response.GetAllAppsResponse
 import com.b1nd.dodamdodam.inapp.application.app.data.toActiveAppResponse
 import com.b1nd.dodamdodam.inapp.application.app.data.toCommand
@@ -124,11 +126,19 @@ class AppUseCase(
     }
 
     fun showApp(appId: UUID): Response<Any> {
+        if (RoleType.ADMIN in currentRoles()) {
+            appService.updateAdminVisibilty(appId, true)
+            return Response.ok("앱이 공개되었어요.")
+        }
         appService.updateVisibility(currentUserId(), appId, true)
         return Response.ok("앱이 공개되었어요.")
     }
 
     fun hideApp(appId: UUID): Response<Any> {
+        if (RoleType.ADMIN in currentRoles()) {
+            appService.updateAdminVisibilty(appId, false)
+            return Response.ok("앱이 비공개되었어요.")
+        }
         appService.updateVisibility(currentUserId(), appId, false)
         return Response.ok("앱이 비공개되었어요.")
     }
@@ -152,4 +162,5 @@ class AppUseCase(
     }
 
     private fun currentUserId() = PassportHolder.current().requireUserId()
+    private fun currentRoles() = PassportHolder.current().role.orEmpty()
 }

--- a/services/service-inapp/src/main/kotlin/com/b1nd/dodamdodam/inapp/domain/app/service/AppService.kt
+++ b/services/service-inapp/src/main/kotlin/com/b1nd/dodamdodam/inapp/domain/app/service/AppService.kt
@@ -143,7 +143,12 @@ class AppService(
     }
 
     fun updateVisibility(userId: UUID, appId: UUID, isVisible: Boolean) {
-        val app = getAppWithMemberPermission(userId, appId)
+        val app = getAppWithOwnerPermission(userId, appId)
+        app.updateVisibility(isVisible)
+    }
+
+    fun updateAdminVisibilty(appId: UUID, isVisible: Boolean) {
+        val app = getApp(appId)
         app.updateVisibility(isVisible)
     }
 

--- a/services/service-inapp/src/test/kotlin/com/b1nd/dodamdodam/inapp/application/app/AppUseCaseVisibilityTest.kt
+++ b/services/service-inapp/src/test/kotlin/com/b1nd/dodamdodam/inapp/application/app/AppUseCaseVisibilityTest.kt
@@ -1,0 +1,156 @@
+package com.b1nd.dodamdodam.inapp.application.app
+
+import com.b1nd.dodamdodam.core.github.client.GitHubClient
+import com.b1nd.dodamdodam.core.security.exception.PassportInvalidException
+import com.b1nd.dodamdodam.core.security.passport.Passport
+import com.b1nd.dodamdodam.core.security.passport.PassportUserDetails
+import com.b1nd.dodamdodam.core.security.passport.enumerations.RoleType
+import com.b1nd.dodamdodam.inapp.domain.app.service.AppService
+import com.b1nd.dodamdodam.inapp.infrastructure.config.InAppProperties
+import com.b1nd.dodamdodam.inapp.infrastructure.user.client.UserQueryClient
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import java.util.UUID
+
+class AppUseCaseVisibilityTest {
+    private val appService = mock(AppService::class.java)
+    private val userQueryClient = mock(UserQueryClient::class.java)
+    private val gitHubClient = mock(GitHubClient::class.java)
+    private val useCase = AppUseCase(
+        appService = appService,
+        userQueryClient = userQueryClient,
+        inAppProperties = InAppProperties(),
+        gitHubClient = gitHubClient,
+    )
+
+    @AfterEach
+    fun clearSecurityContext() {
+        SecurityContextHolder.clearContext()
+    }
+
+    @Test
+    fun `어드민이 앱을 공개하면 소유자 검증 없이 공개된다`() {
+        val appId = UUID.randomUUID()
+        authenticate(userId = UUID.randomUUID(), roles = listOf(RoleType.ADMIN))
+
+        val response = useCase.showApp(appId)
+
+        verify(appService).updateAdminVisibilty(appId, true)
+        verify(appService, never()).updateVisibility(any(), any(), anyBoolean())
+        assertEquals(200, response.status)
+        assertEquals("앱이 공개되었어요.", response.message)
+    }
+
+    @Test
+    fun `어드민이 앱을 비공개하면 소유자 검증 없이 비공개된다`() {
+        val appId = UUID.randomUUID()
+        authenticate(userId = UUID.randomUUID(), roles = listOf(RoleType.ADMIN))
+
+        val response = useCase.hideApp(appId)
+
+        verify(appService).updateAdminVisibilty(appId, false)
+        verify(appService, never()).updateVisibility(any(), any(), anyBoolean())
+        assertEquals(200, response.status)
+        assertEquals("앱이 비공개되었어요.", response.message)
+    }
+
+    @Test
+    fun `어드민 권한이 여러 역할 중 하나여도 어드민 경로를 탄다`() {
+        val appId = UUID.randomUUID()
+        authenticate(userId = UUID.randomUUID(), roles = listOf(RoleType.TEACHER, RoleType.ADMIN))
+
+        useCase.showApp(appId)
+
+        verify(appService).updateAdminVisibilty(appId, true)
+        verify(appService, never()).updateVisibility(any(), any(), anyBoolean())
+    }
+
+    @Test
+    fun `어드민은 패스포트에 userId가 없어도 공개할 수 있다`() {
+        val appId = UUID.randomUUID()
+        authenticate(userId = null, roles = listOf(RoleType.ADMIN))
+
+        val response = useCase.showApp(appId)
+
+        verify(appService).updateAdminVisibilty(appId, true)
+        assertEquals("앱이 공개되었어요.", response.message)
+    }
+
+    @Test
+    fun `일반 사용자가 앱을 공개하면 소유자 검증을 거쳐 공개된다`() {
+        val appId = UUID.randomUUID()
+        val userId = UUID.randomUUID()
+        authenticate(userId = userId, roles = listOf(RoleType.STUDENT))
+
+        val response = useCase.showApp(appId)
+
+        verify(appService).updateVisibility(userId, appId, true)
+        verify(appService, never()).updateAdminVisibilty(any(), anyBoolean())
+        assertEquals(200, response.status)
+        assertEquals("앱이 공개되었어요.", response.message)
+    }
+
+    @Test
+    fun `일반 사용자가 앱을 비공개하면 소유자 검증을 거쳐 비공개된다`() {
+        val appId = UUID.randomUUID()
+        val userId = UUID.randomUUID()
+        authenticate(userId = userId, roles = listOf(RoleType.TEACHER))
+
+        val response = useCase.hideApp(appId)
+
+        verify(appService).updateVisibility(userId, appId, false)
+        verify(appService, never()).updateAdminVisibilty(any(), anyBoolean())
+        assertEquals(200, response.status)
+        assertEquals("앱이 비공개되었어요.", response.message)
+    }
+
+    @Test
+    fun `역할이 없는 패스포트는 일반 사용자로 처리한다`() {
+        val appId = UUID.randomUUID()
+        val userId = UUID.randomUUID()
+        authenticate(userId = userId, roles = null)
+
+        useCase.showApp(appId)
+
+        verify(appService).updateVisibility(userId, appId, true)
+        verify(appService, never()).updateAdminVisibilty(any(), anyBoolean())
+    }
+
+    @Test
+    fun `어드민이 아닌 사용자가 userId 없는 패스포트로 요청하면 예외가 발생한다`() {
+        val appId = UUID.randomUUID()
+        authenticate(userId = null, roles = listOf(RoleType.STUDENT))
+
+        assertThrows<PassportInvalidException> { useCase.showApp(appId) }
+        assertThrows<PassportInvalidException> { useCase.hideApp(appId) }
+
+        verify(appService, never()).updateVisibility(any(), any(), anyBoolean())
+        verify(appService, never()).updateAdminVisibilty(any(), anyBoolean())
+    }
+
+    private fun authenticate(userId: UUID?, roles: List<RoleType>?) {
+        val passport = Passport(
+            userId = userId,
+            username = "tester",
+            role = roles,
+            enabled = true,
+            os = "iOS",
+            version = "1.0.0",
+            issuedAt = 0L,
+            expiredAt = Long.MAX_VALUE,
+        )
+        val details = PassportUserDetails(passport)
+        SecurityContextHolder.getContext().authentication =
+            UsernamePasswordAuthenticationToken(details, null, details.authorities)
+    }
+
+    private fun <T> any(): T = org.mockito.ArgumentMatchers.any()
+    private fun anyBoolean(): Boolean = org.mockito.ArgumentMatchers.anyBoolean()
+}


### PR DESCRIPTION
## 변경 내용
관리자 또는 그 앱을 소유하고 있는 팀의 리더만이 노출여부를 수정할 수 있도록 했습니다.
<!-- 이 PR에서 무엇을 변경했는지 간단히 요약해주세요 -->


## 관련 이슈

<!-- 관련된 이슈를 연결해주세요 -->
- Resolves #302 


## 테스트 방법

<!-- 어떻게 테스트했는지 설명해주세요 -->
- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 완료
- [x] 수동 테스트 완료


## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [ ] 자체 코드 리뷰를 완료했습니다
- [ ] 변경 사항에 대한 테스트를 추가했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] Breaking Changes가 없습니다


## 기타 사항

<!-- 리뷰어가 특별히 주의해서 봐야 할 부분이나 추가 설명 -->