### PR TITLE
fix: 프로젝트 심자 AUTO 신청 처리 개선

### DIFF
--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/entity/NightStudyEntity.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/entity/NightStudyEntity.kt
@@ -50,6 +50,10 @@ class NightStudyEntity (
     var type: NightStudyType,
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "fk_source_project_id")
+    var sourceProject: NightStudyEntity? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "fk_wish_room_id")
     var wishRoom: ProjectRoomEntity? = null,
 ): BaseTimeEntity() {

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/exception/NightStudyException.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/exception/NightStudyException.kt
@@ -22,6 +22,8 @@ class RoomAlreadyAssignedException: BasicException(NightStudyExceptionCode.ROOM_
 
 class AlreadyApprovedException: BasicException(NightStudyExceptionCode.ALREADY_APPROVED)
 
+class SourceProjectNotAllowedException: BasicException(NightStudyExceptionCode.SOURCE_PROJECT_NOT_ALLOWED)
+
 class InvalidNightStudyTypeException: BasicException(NightStudyExceptionCode.INVALID_NIGHT_STUDY_TYPE)
 
 class NightStudyTeamNotFound: BasicException(NightStudyExceptionCode.TEAM_NOT_FOUND)

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/exception/NightStudyExceptionCode.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/exception/NightStudyExceptionCode.kt
@@ -19,6 +19,7 @@ enum class NightStudyExceptionCode(
     NOT_APPLICATION_TIME(HttpStatus.BAD_REQUEST, "지금은 심자 신청 시간이 아니에요."),
     INVALID_START_AT(HttpStatus.BAD_REQUEST, "현재 시간보다 시작일이 과거에요."),
     ALREADY_APPROVED(HttpStatus.CONFLICT, "이미 승인된 심야 자습이에요."),
+    SOURCE_PROJECT_NOT_ALLOWED(HttpStatus.CONFLICT, "원본 프로젝트 심자가 승인 상태가 아니에요."),
     NOT_NIGHT_STUDY_MEMBER(HttpStatus.BAD_REQUEST, "해당 날짜와 교시에 승인된 심야 자습 인원이 아니에요."),
     INVALID_NIGHT_STUDY_TYPE(HttpStatus.BAD_REQUEST, "심야 자습 신청은 1교시 또는 2교시만 신청할 수 있어요."),
     TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "팀을 찾을 수 없어요."),

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepository.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepository.kt
@@ -19,6 +19,14 @@ interface NightStudyQueryRepository {
     fun countAllowedMembersGroupByTypeAndPeriod(): Map<Pair<NightStudyType, Int>, Int>
     fun existsByPublicIdAndUserId(publicId: UUID, userId: UUID): Boolean
     fun existsByUserIdAndPeriodOverlap(userId: UUID, period: Int, type: NightStudyType, startAt: LocalDate, endAt: LocalDate): Boolean
+    fun findActiveByUserIdAndPeriodAndTypesOverlap(
+        userId: UUID,
+        period: Int,
+        types: Set<NightStudyType>,
+        startAt: LocalDate,
+        endAt: LocalDate,
+        excludeNightStudyIds: Set<Long> = emptySet(),
+    ): List<NightStudyEntity>
     fun existsAllowedByUserIdAndPeriodOverlap(userId: UUID, period: Int, startAt: LocalDate, endAt: LocalDate, excludeNightStudyId: Long): Boolean
     fun existsAllowedMemberByUserIdAndDateAndPeriod(userId: UUID, date: LocalDate, period: Int): Boolean
     fun findAllowedUserIdsByDateAndPeriod(date: LocalDate, period: Int): List<UUID>

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepositoryImpl.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyQueryRepositoryImpl.kt
@@ -145,6 +145,32 @@ class NightStudyQueryRepositoryImpl(
             .fetchFirst() != null
     }
 
+    override fun findActiveByUserIdAndPeriodAndTypesOverlap(
+        userId: UUID,
+        period: Int,
+        types: Set<NightStudyType>,
+        startAt: LocalDate,
+        endAt: LocalDate,
+        excludeNightStudyIds: Set<Long>,
+    ): List<NightStudyEntity> {
+        if (types.isEmpty()) return emptyList()
+
+        return queryFactory.select(nightStudyEntity)
+            .from(nightStudyMemberEntity)
+            .join(nightStudyMemberEntity.nightStudy, nightStudyEntity)
+            .where(
+                nightStudyMemberEntity.userId.eq(userId),
+                nightStudyEntity.period.eq(period),
+                nightStudyEntity.type.`in`(types),
+                nightStudyEntity.startAt.loe(endAt),
+                nightStudyEntity.endAt.goe(startAt),
+                nightStudyEntity.status.`in`(NightStudyStatusType.PENDING, NightStudyStatusType.ALLOWED),
+                excludeNightStudyIds.takeIf { it.isNotEmpty() }?.let { nightStudyEntity.id.notIn(it) },
+            )
+            .distinct()
+            .fetch()
+    }
+
     override fun existsAllowedByUserIdAndPeriodOverlap(
         userId: UUID,
         period: Int,

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyRepository.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyRepository.kt
@@ -7,11 +7,11 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
-import java.util.List
 import java.util.UUID
 
 interface NightStudyRepository: JpaRepository<NightStudyEntity, Long> {
     fun findAllByStatus(status: NightStudyStatusType): List<NightStudyEntity>
+    fun findAllBySourceProject(sourceProject: NightStudyEntity): List<NightStudyEntity>
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT nightStudy FROM NightStudyEntity nightStudy WHERE nightStudy.publicId = :publicId")

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyRepository.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/repository/nightStudy/NightStudyRepository.kt
@@ -2,9 +2,18 @@ package com.b1nd.dodamdodam.nightstudy.domain.nightstudy.repository.nightStudy
 
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.entity.NightStudyEntity
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.enumeration.NightStudyStatusType
+import jakarta.persistence.LockModeType
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import java.util.List
+import java.util.UUID
 
 interface NightStudyRepository: JpaRepository<NightStudyEntity, Long> {
     fun findAllByStatus(status: NightStudyStatusType): List<NightStudyEntity>
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT nightStudy FROM NightStudyEntity nightStudy WHERE nightStudy.publicId = :publicId")
+    fun findByPublicIdForUpdate(@Param("publicId") publicId: UUID): NightStudyEntity?
 }

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyService.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyService.kt
@@ -100,7 +100,7 @@ class NightStudyService(
     }
 
     fun delete(userId: UUID, publicId: UUID) {
-        val nightStudy = getByPublicId(publicId)
+        val nightStudy = nightStudyRepository.findByPublicIdForUpdate(publicId) ?: throw NightStudyNotFoundException()
         val isMine = isMine(userId, nightStudy)
 
         if (!isMine) throw NotMyNightStudyException()
@@ -112,6 +112,9 @@ class NightStudyService(
         if (nightStudy.status == NightStudyStatusType.ALLOWED)
             throw AlreadyApprovedException()
 
+        if (nightStudy.type == NightStudyType.PROJECT) {
+            deleteSourceAutos(nightStudy)
+        }
         nightStudyMemberRepository.deleteAllByNightStudy(nightStudy)
         nightStudyRepository.delete(nightStudy)
     }
@@ -132,14 +135,23 @@ class NightStudyService(
         ns.allow()
         if (ns.type == NightStudyType.PROJECT && !wasAlreadyAllowed) {
             val autoPeriod = if (ns.period == 1) 2 else 1
+            val sourceAutosByUserId = getSourceAutosByUserId(ns)
             memberIds.forEach { memberId ->
                 val hasPersonal = nightStudyQueryRepository.existsByUserIdAndPeriodOverlap(
                     memberId, autoPeriod, NightStudyType.PERSONAL, ns.startAt, ns.endAt
                 )
+                if (hasPersonal) return@forEach
+
+                val sourceAutos = sourceAutosByUserId[memberId].orEmpty()
+                if (sourceAutos.isNotEmpty()) {
+                    sourceAutos.forEach { it.pending() }
+                    return@forEach
+                }
+
                 val hasAuto = nightStudyQueryRepository.existsByUserIdAndPeriodOverlap(
                     memberId, autoPeriod, NightStudyType.AUTO, ns.startAt, ns.endAt
                 )
-                if (hasPersonal || hasAuto) return@forEach
+                if (hasAuto) return@forEach
 
                 val nightStudy = NightStudyEntity(
                     description = ns.description,
@@ -148,7 +160,8 @@ class NightStudyService(
                     startAt = ns.startAt,
                     endAt = ns.endAt,
                     status = NightStudyStatusType.PENDING,
-                    needPhone = false
+                    needPhone = false,
+                    sourceProject = ns,
                 )
 
                 save(nightStudy, memberId, null)
@@ -157,11 +170,21 @@ class NightStudyService(
     }
 
     fun reject(publicId: UUID, rejectionReason: String) {
-        getByPublicId(publicId).reject(rejectionReason)
+        val nightStudy = nightStudyRepository.findByPublicIdForUpdate(publicId) ?: throw NightStudyNotFoundException()
+        nightStudy.reject(rejectionReason)
+        if (nightStudy.type == NightStudyType.PROJECT) {
+            nightStudyRepository.findAllBySourceProject(nightStudy).forEach {
+                it.reject(SOURCE_PROJECT_REJECTED_REASON)
+            }
+        }
     }
 
     fun pending(publicId: UUID) {
-        getByPublicId(publicId).pending()
+        val nightStudy = nightStudyRepository.findByPublicIdForUpdate(publicId) ?: throw NightStudyNotFoundException()
+        nightStudy.pending()
+        if (nightStudy.type == NightStudyType.PROJECT) {
+            nightStudyRepository.findAllBySourceProject(nightStudy).forEach { it.pending() }
+        }
     }
 
     fun assignRoom(publicId: UUID, room: ProjectRoomEntity) {
@@ -197,6 +220,23 @@ class NightStudyService(
         return nightStudyMemberRepository.existsByNightStudyAndUserId(nightStudy, userId)
     }
 
+    private fun getSourceAutosByUserId(sourceProject: NightStudyEntity): Map<UUID, List<NightStudyEntity>> {
+        val sourceAutos = nightStudyRepository.findAllBySourceProject(sourceProject)
+        if (sourceAutos.isEmpty()) return emptyMap()
+
+        val membersByNightStudy = nightStudyMemberQueryRepository.findAllMemberUserIdsByNightStudies(sourceAutos)
+        return sourceAutos
+            .flatMap { auto -> membersByNightStudy[auto.id].orEmpty().map { userId -> userId to auto } }
+            .groupBy({ it.first }, { it.second })
+    }
+
+    private fun deleteSourceAutos(sourceProject: NightStudyEntity) {
+        nightStudyRepository.findAllBySourceProject(sourceProject).forEach { auto ->
+            nightStudyMemberRepository.deleteAllByNightStudy(auto)
+            nightStudyRepository.delete(auto)
+        }
+    }
+
     private fun hasAllowedPeriodOverlap(
         userId: UUID,
         period: Int,
@@ -217,5 +257,9 @@ class NightStudyService(
         endAt: LocalDate
     ): Boolean {
         return nightStudyQueryRepository.existsByUserIdAndPeriodOverlap(userId, period, type, startAt, endAt)
+    }
+
+    companion object {
+        private const val SOURCE_PROJECT_REJECTED_REASON = "프로젝트 심자 상태 변경으로 인한 자동 거절"
     }
 }

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyService.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyService.kt
@@ -125,6 +125,9 @@ class NightStudyService(
         val memberIds = nightStudyMemberQueryRepository.findAllUserIdsByNightStudy(ns).distinct()
 
         if (!wasAlreadyAllowed) {
+            if (ns.type == NightStudyType.PERSONAL) {
+                replaceOverlappingAutosWithPersonal(ns, memberIds)
+            }
             memberIds.forEach { memberId ->
                 if (hasAllowedPeriodOverlap(memberId, ns.period, ns.startAt, ns.endAt, ns.id!!)) {
                     throw PeriodOverlappedException()
@@ -262,6 +265,47 @@ class NightStudyService(
     private fun deleteAuto(auto: NightStudyEntity) {
         nightStudyMemberRepository.deleteAllByNightStudy(auto)
         nightStudyRepository.delete(auto)
+    }
+
+    private fun replaceOverlappingAutosWithPersonal(
+        personal: NightStudyEntity,
+        userIds: List<UUID>,
+    ) {
+        userIds.forEach { userId ->
+            val overlappingAutos = nightStudyQueryRepository.findActiveByUserIdAndPeriodAndTypesOverlap(
+                userId = userId,
+                period = personal.period,
+                types = setOf(NightStudyType.AUTO),
+                startAt = personal.startAt,
+                endAt = personal.endAt,
+            )
+            overlappingAutos.forEach { auto ->
+                val remainingRanges = findUncoveredRanges(
+                    startAt = auto.startAt,
+                    endAt = auto.endAt,
+                    coveredRanges = listOf(DateRange(personal.startAt, personal.endAt)),
+                )
+                deleteAuto(auto)
+                remainingRanges.forEach { range ->
+                    save(
+                        NightStudyEntity(
+                            name = auto.name,
+                            description = auto.description,
+                            period = auto.period,
+                            startAt = range.startAt,
+                            endAt = range.endAt,
+                            needPhone = auto.needPhone,
+                            needPhoneReason = auto.needPhoneReason,
+                            status = auto.status,
+                            type = NightStudyType.AUTO,
+                            sourceProject = auto.sourceProject,
+                        ),
+                        userId,
+                        null,
+                    )
+                }
+            }
+        }
     }
 
     private fun findUncoveredRanges(

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyService.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyService.kt
@@ -137,34 +137,22 @@ class NightStudyService(
             val autoPeriod = if (ns.period == 1) 2 else 1
             val sourceAutosByUserId = getSourceAutosByUserId(ns)
             memberIds.forEach { memberId ->
-                val hasPersonal = nightStudyQueryRepository.existsByUserIdAndPeriodOverlap(
-                    memberId, autoPeriod, NightStudyType.PERSONAL, ns.startAt, ns.endAt
-                )
-                if (hasPersonal) return@forEach
-
                 val sourceAutos = sourceAutosByUserId[memberId].orEmpty()
-                if (sourceAutos.isNotEmpty()) {
-                    sourceAutos.forEach { it.pending() }
-                    return@forEach
-                }
-
-                val hasAuto = nightStudyQueryRepository.existsByUserIdAndPeriodOverlap(
-                    memberId, autoPeriod, NightStudyType.AUTO, ns.startAt, ns.endAt
-                )
-                if (hasAuto) return@forEach
-
-                val nightStudy = NightStudyEntity(
-                    description = ns.description,
+                val sourceAutoIds = sourceAutos.mapNotNullTo(mutableSetOf()) { it.id }
+                val coveredNightStudies = nightStudyQueryRepository.findActiveByUserIdAndPeriodAndTypesOverlap(
+                    userId = memberId,
                     period = autoPeriod,
-                    type = NightStudyType.AUTO,
+                    types = AUTO_COVERAGE_TYPES,
                     startAt = ns.startAt,
                     endAt = ns.endAt,
-                    status = NightStudyStatusType.PENDING,
-                    needPhone = false,
-                    sourceProject = ns,
+                    excludeNightStudyIds = sourceAutoIds,
                 )
-
-                save(nightStudy, memberId, null)
+                val uncoveredRanges = findUncoveredRanges(
+                    startAt = ns.startAt,
+                    endAt = ns.endAt,
+                    coveredRanges = coveredNightStudies.map { DateRange(it.startAt, it.endAt) },
+                )
+                syncSourceAutos(ns, memberId, autoPeriod, sourceAutos, uncoveredRanges)
             }
         }
     }
@@ -231,10 +219,79 @@ class NightStudyService(
     }
 
     private fun deleteSourceAutos(sourceProject: NightStudyEntity) {
-        nightStudyRepository.findAllBySourceProject(sourceProject).forEach { auto ->
-            nightStudyMemberRepository.deleteAllByNightStudy(auto)
-            nightStudyRepository.delete(auto)
+        nightStudyRepository.findAllBySourceProject(sourceProject).forEach(::deleteAuto)
+    }
+
+    private fun syncSourceAutos(
+        sourceProject: NightStudyEntity,
+        userId: UUID,
+        period: Int,
+        sourceAutos: List<NightStudyEntity>,
+        desiredRanges: List<DateRange>,
+    ) {
+        val remainingAutos = sourceAutos.toMutableList()
+
+        desiredRanges.forEach { range ->
+            val existingAuto = remainingAutos.firstOrNull {
+                it.startAt == range.startAt && it.endAt == range.endAt
+            }
+            if (existingAuto != null) {
+                existingAuto.pending()
+                remainingAutos.remove(existingAuto)
+            } else {
+                save(
+                    NightStudyEntity(
+                        description = sourceProject.description,
+                        period = period,
+                        type = NightStudyType.AUTO,
+                        startAt = range.startAt,
+                        endAt = range.endAt,
+                        status = NightStudyStatusType.PENDING,
+                        needPhone = false,
+                        sourceProject = sourceProject,
+                    ),
+                    userId,
+                    null,
+                )
+            }
         }
+
+        remainingAutos.forEach(::deleteAuto)
+    }
+
+    private fun deleteAuto(auto: NightStudyEntity) {
+        nightStudyMemberRepository.deleteAllByNightStudy(auto)
+        nightStudyRepository.delete(auto)
+    }
+
+    private fun findUncoveredRanges(
+        startAt: LocalDate,
+        endAt: LocalDate,
+        coveredRanges: List<DateRange>,
+    ): List<DateRange> {
+        if (startAt.isAfter(endAt)) return emptyList()
+
+        val result = mutableListOf<DateRange>()
+        var cursor = startAt
+
+        coveredRanges.sortedBy { it.startAt }.forEach { covered ->
+            val coveredStart = maxOf(covered.startAt, startAt)
+            val coveredEnd = minOf(covered.endAt, endAt)
+            if (coveredEnd.isBefore(cursor) || coveredStart.isAfter(endAt)) return@forEach
+
+            if (coveredStart.isAfter(cursor)) {
+                result += DateRange(cursor, coveredStart.minusDays(1))
+            }
+
+            if (!coveredEnd.isBefore(cursor)) {
+                cursor = coveredEnd.plusDays(1)
+            }
+        }
+
+        if (!cursor.isAfter(endAt)) {
+            result += DateRange(cursor, endAt)
+        }
+        return result
     }
 
     private fun hasAllowedPeriodOverlap(
@@ -261,5 +318,8 @@ class NightStudyService(
 
     companion object {
         private const val SOURCE_PROJECT_REJECTED_REASON = "프로젝트 심자 상태 변경으로 인한 자동 거절"
+        private val AUTO_COVERAGE_TYPES = setOf(NightStudyType.PERSONAL, NightStudyType.AUTO)
     }
+
+    private data class DateRange(val startAt: LocalDate, val endAt: LocalDate)
 }

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyService.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyService.kt
@@ -13,6 +13,7 @@ import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.exception.NotMyNightStud
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.exception.NotProjectNightStudyException
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.exception.PeriodOverlappedException
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.exception.RoomAlreadyAssignedException
+import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.exception.SourceProjectNotAllowedException
 import com.b1nd.dodamdodam.nightstudy.domain.room.entity.ProjectRoomEntity
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.repository.nightStudy.NightStudyBannedRepository
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.repository.nightStudyMember.NightStudyMemberQueryRepository
@@ -121,6 +122,11 @@ class NightStudyService(
 
     fun allow(publicId: UUID) {
         val ns = nightStudyRepository.findByPublicIdForUpdate(publicId) ?: throw NightStudyNotFoundException()
+        if (
+            ns.type == NightStudyType.AUTO &&
+            ns.sourceProject?.status?.let { it != NightStudyStatusType.ALLOWED } == true
+        ) throw SourceProjectNotAllowedException()
+
         val wasAlreadyAllowed = ns.status == NightStudyStatusType.ALLOWED
         val memberIds = nightStudyMemberQueryRepository.findAllUserIdsByNightStudy(ns).distinct()
 

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyService.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyService.kt
@@ -117,7 +117,7 @@ class NightStudyService(
     }
 
     fun allow(publicId: UUID) {
-        val ns = getByPublicId(publicId)
+        val ns = nightStudyRepository.findByPublicIdForUpdate(publicId) ?: throw NightStudyNotFoundException()
         val wasAlreadyAllowed = ns.status == NightStudyStatusType.ALLOWED
         val memberIds = nightStudyMemberQueryRepository.findAllUserIdsByNightStudy(ns).distinct()
 

--- a/services/service-nightstudy/src/main/resources/database/migration/V20260819__link_auto_to_source_project.sql
+++ b/services/service-nightstudy/src/main/resources/database/migration/V20260819__link_auto_to_source_project.sql
@@ -1,0 +1,9 @@
+ALTER TABLE night_studies
+    ADD COLUMN fk_source_project_id BIGINT NULL;
+
+CREATE INDEX IDX_NIGHT_STUDIES_SOURCE_PROJECT
+    ON night_studies (fk_source_project_id);
+
+ALTER TABLE night_studies
+    ADD CONSTRAINT FK_NIGHT_STUDIES_ON_FK_SOURCE_PROJECT
+    FOREIGN KEY (fk_source_project_id) REFERENCES night_studies (id);

--- a/services/service-nightstudy/src/test/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyServiceTest.kt
+++ b/services/service-nightstudy/src/test/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyServiceTest.kt
@@ -10,6 +10,7 @@ import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.repository.nightStudyMem
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.repository.nightStudyMember.NightStudyMemberRepository
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.mockito.ArgumentCaptor
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
@@ -37,37 +38,31 @@ class NightStudyServiceTest {
         val publicId = UUID.randomUUID()
         val memberId = UUID.randomUUID()
         val project = projectNightStudy(period = 1)
+        val existingAuto = autoNightStudy(null, NightStudyStatusType.PENDING)
         `when`(nightStudyRepository.findByPublicIdForUpdate(publicId)).thenReturn(project)
         `when`(nightStudyMemberQueryRepository.findAllUserIdsByNightStudy(project))
             .thenReturn(listOf(memberId, memberId))
         `when`(
-            nightStudyQueryRepository.existsByUserIdAndPeriodOverlap(
+            nightStudyQueryRepository.findActiveByUserIdAndPeriodAndTypesOverlap(
                 memberId,
                 2,
-                NightStudyType.PERSONAL,
+                setOf(NightStudyType.PERSONAL, NightStudyType.AUTO),
                 project.startAt,
                 project.endAt,
+                emptySet(),
             )
-        ).thenReturn(false)
-        `when`(
-            nightStudyQueryRepository.existsByUserIdAndPeriodOverlap(
-                memberId,
-                2,
-                NightStudyType.AUTO,
-                project.startAt,
-                project.endAt,
-            )
-        ).thenReturn(true)
+        ).thenReturn(listOf(existingAuto))
 
         service.allow(publicId)
 
         assertEquals(NightStudyStatusType.ALLOWED, project.status)
-        verify(nightStudyQueryRepository, times(1)).existsByUserIdAndPeriodOverlap(
+        verify(nightStudyQueryRepository, times(1)).findActiveByUserIdAndPeriodAndTypesOverlap(
             memberId,
             2,
-            NightStudyType.AUTO,
+            setOf(NightStudyType.PERSONAL, NightStudyType.AUTO),
             project.startAt,
             project.endAt,
+            emptySet(),
         )
         verify(nightStudyRepository, never()).save(org.mockito.ArgumentMatchers.any())
     }
@@ -77,27 +72,30 @@ class NightStudyServiceTest {
         val publicId = UUID.randomUUID()
         val memberId = UUID.randomUUID()
         val project = projectNightStudy(period = 2)
+        val personal = personalNightStudy(period = 1, startAt = project.startAt, endAt = project.endAt)
         `when`(nightStudyRepository.findByPublicIdForUpdate(publicId)).thenReturn(project)
         `when`(nightStudyMemberQueryRepository.findAllUserIdsByNightStudy(project)).thenReturn(listOf(memberId))
         `when`(
-            nightStudyQueryRepository.existsByUserIdAndPeriodOverlap(
+            nightStudyQueryRepository.findActiveByUserIdAndPeriodAndTypesOverlap(
                 memberId,
                 1,
-                NightStudyType.PERSONAL,
+                setOf(NightStudyType.PERSONAL, NightStudyType.AUTO),
                 project.startAt,
                 project.endAt,
+                emptySet(),
             )
-        ).thenReturn(true)
+        ).thenReturn(listOf(personal))
 
         service.allow(publicId)
 
         assertEquals(NightStudyStatusType.ALLOWED, project.status)
-        verify(nightStudyQueryRepository).existsByUserIdAndPeriodOverlap(
+        verify(nightStudyQueryRepository).findActiveByUserIdAndPeriodAndTypesOverlap(
             memberId,
             1,
-            NightStudyType.PERSONAL,
+            setOf(NightStudyType.PERSONAL, NightStudyType.AUTO),
             project.startAt,
             project.endAt,
+            emptySet(),
         )
         verify(nightStudyRepository, never()).save(org.mockito.ArgumentMatchers.any())
     }
@@ -113,12 +111,64 @@ class NightStudyServiceTest {
         `when`(nightStudyRepository.findAllBySourceProject(project)).thenReturn(listOf(auto))
         `when`(nightStudyMemberQueryRepository.findAllMemberUserIdsByNightStudies(listOf(auto)))
             .thenReturn(mapOf(auto.id!! to listOf(memberId)))
+        `when`(
+            nightStudyQueryRepository.findActiveByUserIdAndPeriodAndTypesOverlap(
+                memberId,
+                2,
+                setOf(NightStudyType.PERSONAL, NightStudyType.AUTO),
+                project.startAt,
+                project.endAt,
+                setOf(auto.id!!),
+            )
+        ).thenReturn(emptyList())
 
         service.allow(publicId)
 
         assertEquals(NightStudyStatusType.ALLOWED, project.status)
         assertEquals(NightStudyStatusType.PENDING, auto.status)
         verify(nightStudyRepository, never()).save(org.mockito.ArgumentMatchers.any())
+    }
+
+    @Test
+    fun `개인 심자가 일부 날짜에만 있으면 비어 있는 기간별로 자동 심자를 생성한다`() {
+        val publicId = UUID.randomUUID()
+        val memberId = UUID.randomUUID()
+        val project = projectNightStudy(period = 1)
+        val personal = personalNightStudy(
+            period = 2,
+            startAt = LocalDate.of(2026, 8, 20),
+            endAt = LocalDate.of(2026, 8, 20),
+        )
+        `when`(nightStudyRepository.findByPublicIdForUpdate(publicId)).thenReturn(project)
+        `when`(nightStudyMemberQueryRepository.findAllUserIdsByNightStudy(project)).thenReturn(listOf(memberId))
+        `when`(
+            nightStudyQueryRepository.findActiveByUserIdAndPeriodAndTypesOverlap(
+                memberId,
+                2,
+                setOf(NightStudyType.PERSONAL, NightStudyType.AUTO),
+                project.startAt,
+                project.endAt,
+                emptySet(),
+            )
+        ).thenReturn(listOf(personal))
+        `when`(nightStudyRepository.save(org.mockito.ArgumentMatchers.any(NightStudyEntity::class.java)))
+            .thenAnswer { it.getArgument(0) }
+
+        service.allow(publicId)
+
+        val captor = ArgumentCaptor.forClass(NightStudyEntity::class.java)
+        verify(nightStudyRepository, times(2)).save(captor.capture())
+        assertEquals(
+            listOf(
+                LocalDate.of(2026, 8, 18) to LocalDate.of(2026, 8, 19),
+                LocalDate.of(2026, 8, 21) to LocalDate.of(2026, 8, 21),
+            ),
+            captor.allValues.map { it.startAt to it.endAt },
+        )
+        captor.allValues.forEach {
+            assertEquals(NightStudyType.AUTO, it.type)
+            assertEquals(project, it.sourceProject)
+        }
     }
 
     @Test
@@ -186,14 +236,14 @@ class NightStudyServiceTest {
     }
 
     private fun autoNightStudy(
-        sourceProject: NightStudyEntity,
+        sourceProject: NightStudyEntity?,
         status: NightStudyStatusType,
     ): NightStudyEntity {
         val auto = NightStudyEntity(
             description = "자동 심자",
-            period = if (sourceProject.period == 1) 2 else 1,
-            startAt = sourceProject.startAt,
-            endAt = sourceProject.endAt,
+            period = if (sourceProject?.period == 2) 1 else 2,
+            startAt = sourceProject?.startAt ?: LocalDate.of(2026, 8, 18),
+            endAt = sourceProject?.endAt ?: LocalDate.of(2026, 8, 21),
             needPhone = false,
             status = status,
             type = NightStudyType.AUTO,
@@ -205,4 +255,18 @@ class NightStudyServiceTest {
         }
         return auto
     }
+
+    private fun personalNightStudy(
+        period: Int,
+        startAt: LocalDate,
+        endAt: LocalDate,
+    ) = NightStudyEntity(
+        description = "개인 심자",
+        period = period,
+        startAt = startAt,
+        endAt = endAt,
+        needPhone = false,
+        status = NightStudyStatusType.PENDING,
+        type = NightStudyType.PERSONAL,
+    )
 }

--- a/services/service-nightstudy/src/test/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyServiceTest.kt
+++ b/services/service-nightstudy/src/test/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyServiceTest.kt
@@ -3,12 +3,14 @@ package com.b1nd.dodamdodam.nightstudy.domain.nightstudy.service
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.entity.NightStudyEntity
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.enumeration.NightStudyStatusType
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.enumeration.NightStudyType
+import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.exception.SourceProjectNotAllowedException
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.repository.nightStudy.NightStudyBannedRepository
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.repository.nightStudy.NightStudyQueryRepository
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.repository.nightStudy.NightStudyRepository
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.repository.nightStudyMember.NightStudyMemberQueryRepository
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.repository.nightStudyMember.NightStudyMemberRepository
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentCaptor
 import org.mockito.Mockito.`when`
@@ -291,6 +293,20 @@ class NightStudyServiceTest {
             assertEquals(NightStudyStatusType.ALLOWED, it.status)
             assertEquals(project, it.sourceProject)
         }
+    }
+
+    @Test
+    fun `원본 프로젝트가 승인 상태가 아니면 연결된 자동 심자를 승인할 수 없다`() {
+        val publicId = UUID.randomUUID()
+        val project = projectNightStudy(period = 1)
+        val auto = autoNightStudy(project, NightStudyStatusType.PENDING)
+        `when`(nightStudyRepository.findByPublicIdForUpdate(publicId)).thenReturn(auto)
+
+        assertThrows(SourceProjectNotAllowedException::class.java) {
+            service.allow(publicId)
+        }
+
+        assertEquals(NightStudyStatusType.PENDING, auto.status)
     }
 
     private fun projectNightStudy(period: Int): NightStudyEntity {

--- a/services/service-nightstudy/src/test/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyServiceTest.kt
+++ b/services/service-nightstudy/src/test/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyServiceTest.kt
@@ -218,6 +218,81 @@ class NightStudyServiceTest {
         verify(nightStudyRepository).delete(project)
     }
 
+    @Test
+    fun `개인 심자 승인 시 완전히 겹치는 자동 심자를 제거한다`() {
+        val publicId = UUID.randomUUID()
+        val userId = UUID.randomUUID()
+        val project = projectNightStudy(period = 1).apply { allow() }
+        val auto = autoNightStudy(project, NightStudyStatusType.ALLOWED)
+        val personal = personalNightStudy(
+            period = 2,
+            startAt = auto.startAt,
+            endAt = auto.endAt,
+        )
+        `when`(nightStudyRepository.findByPublicIdForUpdate(publicId)).thenReturn(personal)
+        `when`(nightStudyMemberQueryRepository.findAllUserIdsByNightStudy(personal)).thenReturn(listOf(userId))
+        `when`(
+            nightStudyQueryRepository.findActiveByUserIdAndPeriodAndTypesOverlap(
+                userId,
+                2,
+                setOf(NightStudyType.AUTO),
+                personal.startAt,
+                personal.endAt,
+                emptySet(),
+            )
+        ).thenReturn(listOf(auto))
+
+        service.allow(publicId)
+
+        assertEquals(NightStudyStatusType.ALLOWED, personal.status)
+        verify(nightStudyMemberRepository).deleteAllByNightStudy(auto)
+        verify(nightStudyRepository).delete(auto)
+        verify(nightStudyRepository, never()).save(org.mockito.ArgumentMatchers.any())
+    }
+
+    @Test
+    fun `개인 심자 승인 시 자동 심자의 겹치지 않는 기간은 보존한다`() {
+        val publicId = UUID.randomUUID()
+        val userId = UUID.randomUUID()
+        val project = projectNightStudy(period = 1).apply { allow() }
+        val auto = autoNightStudy(project, NightStudyStatusType.ALLOWED)
+        val personal = personalNightStudy(
+            period = 2,
+            startAt = LocalDate.of(2026, 8, 20),
+            endAt = LocalDate.of(2026, 8, 20),
+        )
+        `when`(nightStudyRepository.findByPublicIdForUpdate(publicId)).thenReturn(personal)
+        `when`(nightStudyMemberQueryRepository.findAllUserIdsByNightStudy(personal)).thenReturn(listOf(userId))
+        `when`(
+            nightStudyQueryRepository.findActiveByUserIdAndPeriodAndTypesOverlap(
+                userId,
+                2,
+                setOf(NightStudyType.AUTO),
+                personal.startAt,
+                personal.endAt,
+                emptySet(),
+            )
+        ).thenReturn(listOf(auto))
+        `when`(nightStudyRepository.save(org.mockito.ArgumentMatchers.any(NightStudyEntity::class.java)))
+            .thenAnswer { it.getArgument(0) }
+
+        service.allow(publicId)
+
+        val captor = ArgumentCaptor.forClass(NightStudyEntity::class.java)
+        verify(nightStudyRepository, times(2)).save(captor.capture())
+        assertEquals(
+            listOf(
+                LocalDate.of(2026, 8, 18) to LocalDate.of(2026, 8, 19),
+                LocalDate.of(2026, 8, 21) to LocalDate.of(2026, 8, 21),
+            ),
+            captor.allValues.map { it.startAt to it.endAt },
+        )
+        captor.allValues.forEach {
+            assertEquals(NightStudyStatusType.ALLOWED, it.status)
+            assertEquals(project, it.sourceProject)
+        }
+    }
+
     private fun projectNightStudy(period: Int): NightStudyEntity {
         val project = NightStudyEntity(
             name = "프로젝트",
@@ -260,13 +335,20 @@ class NightStudyServiceTest {
         period: Int,
         startAt: LocalDate,
         endAt: LocalDate,
-    ) = NightStudyEntity(
-        description = "개인 심자",
-        period = period,
-        startAt = startAt,
-        endAt = endAt,
-        needPhone = false,
-        status = NightStudyStatusType.PENDING,
-        type = NightStudyType.PERSONAL,
-    )
+    ): NightStudyEntity {
+        val personal = NightStudyEntity(
+            description = "개인 심자",
+            period = period,
+            startAt = startAt,
+            endAt = endAt,
+            needPhone = false,
+            status = NightStudyStatusType.PENDING,
+            type = NightStudyType.PERSONAL,
+        )
+        NightStudyEntity::class.java.getDeclaredField("id").apply {
+            isAccessible = true
+            set(personal, 3L)
+        }
+        return personal
+    }
 }

--- a/services/service-nightstudy/src/test/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyServiceTest.kt
+++ b/services/service-nightstudy/src/test/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyServiceTest.kt
@@ -102,6 +102,72 @@ class NightStudyServiceTest {
         verify(nightStudyRepository, never()).save(org.mockito.ArgumentMatchers.any())
     }
 
+    @Test
+    fun `프로젝트 재승인 시 연결된 자동 심자를 대기 상태로 재사용한다`() {
+        val publicId = UUID.randomUUID()
+        val memberId = UUID.randomUUID()
+        val project = projectNightStudy(period = 1)
+        val auto = autoNightStudy(project, NightStudyStatusType.REJECTED)
+        `when`(nightStudyRepository.findByPublicIdForUpdate(publicId)).thenReturn(project)
+        `when`(nightStudyMemberQueryRepository.findAllUserIdsByNightStudy(project)).thenReturn(listOf(memberId))
+        `when`(nightStudyRepository.findAllBySourceProject(project)).thenReturn(listOf(auto))
+        `when`(nightStudyMemberQueryRepository.findAllMemberUserIdsByNightStudies(listOf(auto)))
+            .thenReturn(mapOf(auto.id!! to listOf(memberId)))
+
+        service.allow(publicId)
+
+        assertEquals(NightStudyStatusType.ALLOWED, project.status)
+        assertEquals(NightStudyStatusType.PENDING, auto.status)
+        verify(nightStudyRepository, never()).save(org.mockito.ArgumentMatchers.any())
+    }
+
+    @Test
+    fun `프로젝트 거절 시 연결된 자동 심자도 거절한다`() {
+        val publicId = UUID.randomUUID()
+        val project = projectNightStudy(period = 1).apply { allow() }
+        val auto = autoNightStudy(project, NightStudyStatusType.ALLOWED)
+        `when`(nightStudyRepository.findByPublicIdForUpdate(publicId)).thenReturn(project)
+        `when`(nightStudyRepository.findAllBySourceProject(project)).thenReturn(listOf(auto))
+
+        service.reject(publicId, "프로젝트 거절")
+
+        assertEquals(NightStudyStatusType.REJECTED, project.status)
+        assertEquals(NightStudyStatusType.REJECTED, auto.status)
+        assertEquals("프로젝트 심자 상태 변경으로 인한 자동 거절", auto.rejectionReason)
+    }
+
+    @Test
+    fun `프로젝트 대기 전환 시 연결된 자동 심자도 대기 상태로 변경한다`() {
+        val publicId = UUID.randomUUID()
+        val project = projectNightStudy(period = 1).apply { allow() }
+        val auto = autoNightStudy(project, NightStudyStatusType.ALLOWED)
+        `when`(nightStudyRepository.findByPublicIdForUpdate(publicId)).thenReturn(project)
+        `when`(nightStudyRepository.findAllBySourceProject(project)).thenReturn(listOf(auto))
+
+        service.pending(publicId)
+
+        assertEquals(NightStudyStatusType.PENDING, project.status)
+        assertEquals(NightStudyStatusType.PENDING, auto.status)
+    }
+
+    @Test
+    fun `프로젝트 삭제 시 연결된 자동 심자를 먼저 삭제한다`() {
+        val publicId = UUID.randomUUID()
+        val userId = UUID.randomUUID()
+        val project = projectNightStudy(period = 1)
+        val auto = autoNightStudy(project, NightStudyStatusType.PENDING)
+        `when`(nightStudyRepository.findByPublicIdForUpdate(publicId)).thenReturn(project)
+        `when`(nightStudyMemberRepository.existsByNightStudyAndUserId(project, userId)).thenReturn(true)
+        `when`(nightStudyMemberQueryRepository.findLeaderUserIdByNightStudy(project)).thenReturn(userId)
+        `when`(nightStudyRepository.findAllBySourceProject(project)).thenReturn(listOf(auto))
+
+        service.delete(userId, publicId)
+
+        verify(nightStudyMemberRepository).deleteAllByNightStudy(auto)
+        verify(nightStudyRepository).delete(auto)
+        verify(nightStudyRepository).delete(project)
+    }
+
     private fun projectNightStudy(period: Int): NightStudyEntity {
         val project = NightStudyEntity(
             name = "프로젝트",
@@ -117,5 +183,26 @@ class NightStudyServiceTest {
             set(project, 1L)
         }
         return project
+    }
+
+    private fun autoNightStudy(
+        sourceProject: NightStudyEntity,
+        status: NightStudyStatusType,
+    ): NightStudyEntity {
+        val auto = NightStudyEntity(
+            description = "자동 심자",
+            period = if (sourceProject.period == 1) 2 else 1,
+            startAt = sourceProject.startAt,
+            endAt = sourceProject.endAt,
+            needPhone = false,
+            status = status,
+            type = NightStudyType.AUTO,
+            sourceProject = sourceProject,
+        )
+        NightStudyEntity::class.java.getDeclaredField("id").apply {
+            isAccessible = true
+            set(auto, 2L)
+        }
+        return auto
     }
 }

--- a/services/service-nightstudy/src/test/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyServiceTest.kt
+++ b/services/service-nightstudy/src/test/kotlin/com/b1nd/dodamdodam/nightstudy/domain/nightstudy/service/NightStudyServiceTest.kt
@@ -37,7 +37,7 @@ class NightStudyServiceTest {
         val publicId = UUID.randomUUID()
         val memberId = UUID.randomUUID()
         val project = projectNightStudy(period = 1)
-        `when`(nightStudyQueryRepository.findByPublicId(publicId)).thenReturn(project)
+        `when`(nightStudyRepository.findByPublicIdForUpdate(publicId)).thenReturn(project)
         `when`(nightStudyMemberQueryRepository.findAllUserIdsByNightStudy(project))
             .thenReturn(listOf(memberId, memberId))
         `when`(
@@ -77,7 +77,7 @@ class NightStudyServiceTest {
         val publicId = UUID.randomUUID()
         val memberId = UUID.randomUUID()
         val project = projectNightStudy(period = 2)
-        `when`(nightStudyQueryRepository.findByPublicId(publicId)).thenReturn(project)
+        `when`(nightStudyRepository.findByPublicIdForUpdate(publicId)).thenReturn(project)
         `when`(nightStudyMemberQueryRepository.findAllUserIdsByNightStudy(project)).thenReturn(listOf(memberId))
         `when`(
             nightStudyQueryRepository.existsByUserIdAndPeriodOverlap(
@@ -102,13 +102,20 @@ class NightStudyServiceTest {
         verify(nightStudyRepository, never()).save(org.mockito.ArgumentMatchers.any())
     }
 
-    private fun projectNightStudy(period: Int) = NightStudyEntity(
-        name = "프로젝트",
-        description = "프로젝트 심자",
-        period = period,
-        startAt = LocalDate.of(2026, 8, 18),
-        endAt = LocalDate.of(2026, 8, 21),
-        needPhone = false,
-        type = NightStudyType.PROJECT,
-    )
+    private fun projectNightStudy(period: Int): NightStudyEntity {
+        val project = NightStudyEntity(
+            name = "프로젝트",
+            description = "프로젝트 심자",
+            period = period,
+            startAt = LocalDate.of(2026, 8, 18),
+            endAt = LocalDate.of(2026, 8, 21),
+            needPhone = false,
+            type = NightStudyType.PROJECT,
+        )
+        NightStudyEntity::class.java.getDeclaredField("id").apply {
+            isAccessible = true
+            set(project, 1L)
+        }
+        return project
+    }
 }


### PR DESCRIPTION
## 변경 내용

프로젝트 심자 승인으로 생성되는 AUTO 신청의 상태와 중복 처리 로직을 개선했습니다.

- 동시에 승인해도 AUTO 신청이 중복 생성되지 않습니다.
- 프로젝트가 대기·거절·삭제되면 연결된 AUTO 신청도 함께 처리됩니다.
- 개인 심자와 기간이 겹치면 AUTO 신청의 겹치는 기간만 제거됩니다.
- 원본 프로젝트가 승인 상태가 아니면 AUTO 신청을 승인할 수 없습니다.

## 관련 이슈

- Resolves #305

## 테스트 방법

- [x] 단위 테스트 추가/수정
- [ ] 통합 테스트 완료
- [ ] 수동 테스트 완료

프로젝트 상태 변경, AUTO 중복 생성, 개인 심자와의 기간 중복 상황을 단위 테스트로 검증했습니다.

## 스크린샷 (UI 변경 시)

UI 변경 사항이 없습니다.

## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 완료했습니다
- [x] 변경 사항에 대한 테스트를 추가했습니다
- [x] 문서를 업데이트했습니다 (필요한 경우)
- [x] Breaking Changes가 없습니다

## 기타 사항

AUTO 신청과 원본 프로젝트를 연결하는 DB 마이그레이션이 포함되어 있습니다.