### PR TITLE
fix: 심자 인원 조회 응답 구조 복구 (#307)

### DIFF
--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/NightStudyUseCase.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/NightStudyUseCase.kt
@@ -214,7 +214,7 @@ class NightStudyUseCase(
                     floor = resolveFloor(selected.nightStudy, user),
                     grade = grade,
                     period = selected.period,
-                    gender = NightStudyTotalCountResponse.Gender.MALE,
+                    type = selected.nightStudy.type,
                 )
             }
 

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/data/response/NightStudyTotalCountResponse.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/data/response/NightStudyTotalCountResponse.kt
@@ -1,5 +1,7 @@
 package com.b1nd.dodamdodam.nightstudy.application.nightstudy.data.response
 
+import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.enumeration.NightStudyType
+
 data class NightStudyTotalCountResponse(
     val floors: List<FloorCount>,
     val grades: List<GradeCount>,
@@ -16,37 +18,32 @@ data class NightStudyTotalCountResponse(
     )
 
     data class PeriodCount(
-        val period1: GenderCount,
-        val period2: GenderCount,
+        val period1: TypeCount,
+        val period2: TypeCount,
     )
 
-    data class GenderCount(
-        val male: Int,
-        val female: Int,
+    data class TypeCount(
+        val personal: Int,
+        val project: Int,
     )
 
     data class MemberCount(
         val floor: Int,
         val grade: Int,
         val period: Int,
-        val gender: Gender,
+        val type: NightStudyType,
     )
-
-    enum class Gender {
-        MALE,
-        FEMALE,
-    }
 
     companion object {
         fun of(members: List<MemberCount>): NightStudyTotalCountResponse {
-            fun genderCount(filtered: List<MemberCount>, period: Int) = GenderCount(
-                male = filtered.count { it.period == period && it.gender == Gender.MALE },
-                female = filtered.count { it.period == period && it.gender == Gender.FEMALE },
+            fun typeCount(filtered: List<MemberCount>, period: Int) = TypeCount(
+                personal = filtered.count { it.period == period && it.type == NightStudyType.PERSONAL },
+                project = filtered.count { it.period == period && it.type == NightStudyType.PROJECT },
             )
 
             fun periodCount(filtered: List<MemberCount>) = PeriodCount(
-                period1 = genderCount(filtered, 1),
-                period2 = genderCount(filtered, 2),
+                period1 = typeCount(filtered, 1),
+                period2 = typeCount(filtered, 2),
             )
 
             val floors = listOf(2, 3).map { floor ->

--- a/services/service-nightstudy/src/test/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/NightStudyUseCaseCountTest.kt
+++ b/services/service-nightstudy/src/test/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/NightStudyUseCaseCountTest.kt
@@ -52,14 +52,14 @@ class NightStudyUseCaseCountTest {
 
         val result = useCase.countTotalMembers().data!!
 
-        assertEquals(1, result.total.period1.male)
-        assertEquals(1, result.total.period2.male)
-        assertEquals(0, result.total.period1.female)
-        assertEquals(0, result.total.period2.female)
-        assertEquals(1, result.floors.single { it.floor == 3 }.count.period1.male)
-        assertEquals(1, result.floors.single { it.floor == 2 }.count.period2.male)
-        assertEquals(1, result.grades.single { it.grade == 1 }.count.period1.male)
-        assertEquals(1, result.grades.single { it.grade == 1 }.count.period2.male)
+        assertEquals(1, result.total.period1.project)
+        assertEquals(0, result.total.period1.personal)
+        assertEquals(0, result.total.period2.project)
+        assertEquals(1, result.total.period2.personal)
+        assertEquals(1, result.floors.single { it.floor == 3 }.count.period1.project)
+        assertEquals(1, result.floors.single { it.floor == 2 }.count.period2.personal)
+        assertEquals(1, result.grades.single { it.grade == 1 }.count.period1.project)
+        assertEquals(1, result.grades.single { it.grade == 1 }.count.period2.personal)
     }
 
     private fun nightStudy(


### PR DESCRIPTION
## 변경 내용

- 심자 인원 조회 API의 집계 기준을 `male/female`에서 `personal/project`로 복구했습니다.
- 신청 유형에 따라 일반 심자와 프로젝트 심자를 각각 집계하도록 수정했습니다.
- 사용자·차수별 중복 제거 및 층·학년별 집계 로직은 기존대로 유지했습니다.
- 변경된 응답 구조에 맞게 단위 테스트를 수정했습니다.

## 관련 이슈

- Resolves #307

## 테스트 방법

- [x] 단위 테스트 추가/수정
- [ ] 통합 테스트 완료
- [ ] 수동 테스트 완료


## 스크린샷 (UI 변경 시)

서버 API 응답 구조 수정으로 별도의 UI 변경 사항은 없습니다.

## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 완료했습니다
- [x] 변경 사항에 대한 테스트를 추가했습니다
- [x] 문서를 업데이트했습니다 (필요한 경우)
- [ ] Breaking Changes가 없습니다

## 기타 사항

`GET /applications/total` 응답 필드가 다음과 같이 변경됩니다.

- 변경 전: `period1.male`, `period1.female`
- 변경 후: `period1.personal`, `period1.project`

웹과 앱에서 사용하던 기존 API 계약을 복구하는 변경입니다.