### PR TITLE
Feature/#309 outsleeping late application

### DIFF
--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/NightStudyUseCase.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/NightStudyUseCase.kt
@@ -333,8 +333,9 @@ class NightStudyUseCase(
     }
 
     private fun validateApplicationAvailability(stratAt: LocalDate, period: Int) {
-        val now = LocalDateTime.now()
-        val deadline = LocalDate.now(ZoneId.of("Asia/Seoul")).atTime(20, 30)
+        val zone = ZoneId.of("Asia/Seoul")
+        val now = LocalDateTime.now(zone)
+        val deadline = LocalDate.now(zone).atTime(20, 30)
         if (now.isAfter(deadline))
             throw BasicException(NightStudyExceptionCode.NOT_APPLICATION_TIME)
         if (stratAt.isBefore(now.toLocalDate()))

--- a/services/service-out-sleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/application/outsleeping/OutSleepingUseCase.kt
+++ b/services/service-out-sleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/application/outsleeping/OutSleepingUseCase.kt
@@ -33,21 +33,21 @@ class OutSleepingUseCase(
 ) {
 
     fun apply(request: ApplyOutSleepingRequest): Response<Any> {
-        deadlineService.validateDeadline()
+        val type = deadlineService.validateDeadline()
         val userId = currentUserId()
         outSleepingService.validateDate(request.startAt, request.endAt)
         outSleepingService.validateDuplicateDate(userId, request.startAt, request.endAt)
-        outSleepingService.create(request.toEntity(userId))
+        outSleepingService.create(request.toEntity(userId, type))
         return Response.created("외박 신청이 완료되었어요.")
     }
 
     fun modify(publicId: UUID, request: ModifyOutSleepingRequest): Response<Any> {
-        deadlineService.validateDeadline()
+        val type = deadlineService.validateDeadline()
         val userId = currentUserId()
         val outSleeping = outSleepingService.getByPublicId(publicId)
         outSleepingService.validateOwner(outSleeping, userId)
         outSleepingService.validateDate(request.startAt, request.endAt)
-        outSleeping.update(request.reason, request.startAt, request.endAt)
+        outSleeping.update(request.reason, request.startAt, request.endAt, type)
         return Response.ok("외박 신청이 수정되었어요.")
     }
 

--- a/services/service-out-sleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/application/outsleeping/data/OutSleepingMapper.kt
+++ b/services/service-out-sleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/application/outsleeping/data/OutSleepingMapper.kt
@@ -10,6 +10,7 @@ import com.b1nd.dodamdodam.outsleeping.application.outsleeping.data.response.Out
 import com.b1nd.dodamdodam.outsleeping.application.outsleeping.data.response.StudentResponse
 import com.b1nd.dodamdodam.outsleeping.domain.deadline.entity.OutSleepingDeadlineEntity
 import com.b1nd.dodamdodam.outsleeping.domain.outsleeping.entity.OutSleepingEntity
+import com.b1nd.dodamdodam.outsleeping.domain.outsleeping.enumeration.OutSleepingStatusType
 import java.util.UUID
 
 
@@ -26,11 +27,12 @@ fun List<OutSleepingEntity>.toGetOutSleepings(): GetOutSleepingResponse =
         .addAllOutSleepings(map { it.toGrpcResponse() })
         .build()
 
-fun ApplyOutSleepingRequest.toEntity(userId: UUID) = OutSleepingEntity(
+fun ApplyOutSleepingRequest.toEntity(userId: UUID, type: OutSleepingStatusType) = OutSleepingEntity(
     userId = userId,
     reason = reason,
     startAt = startAt,
     endAt = endAt,
+    statusType = type
 )
 
 fun OutSleepingEntity.toResponse(userInfo: UserResponse?) = OutSleepingResponse(

--- a/services/service-out-sleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/application/outsleeping/data/OutSleepingMapper.kt
+++ b/services/service-out-sleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/application/outsleeping/data/OutSleepingMapper.kt
@@ -39,6 +39,7 @@ fun OutSleepingEntity.toResponse(userInfo: UserResponse?) = OutSleepingResponse(
     publicId = publicId!!,
     reason = reason,
     status = status,
+    statusType = statusType,
     student = userInfo?.student?.toStudentResponse(userInfo.name),
     startAt = startAt,
     endAt = endAt,
@@ -48,6 +49,7 @@ fun OutSleepingEntity.toMyResponse() = MyOutSleepingResponse(
     publicId = publicId!!,
     reason = reason,
     status = status,
+    statusType = statusType,
     startAt = startAt,
     endAt = endAt,
 )

--- a/services/service-out-sleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/application/outsleeping/data/response/MyOutSleepingResponse.kt
+++ b/services/service-out-sleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/application/outsleeping/data/response/MyOutSleepingResponse.kt
@@ -1,6 +1,7 @@
 package com.b1nd.dodamdodam.outsleeping.application.outsleeping.data.response
 
 import com.b1nd.dodamdodam.outsleeping.domain.outsleeping.enumeration.OutSleepingStatus
+import com.b1nd.dodamdodam.outsleeping.domain.outsleeping.enumeration.OutSleepingStatusType
 import java.time.LocalDate
 import java.util.UUID
 
@@ -8,6 +9,7 @@ data class MyOutSleepingResponse(
     val publicId: UUID,
     val reason: String,
     val status: OutSleepingStatus,
+    val statusType: OutSleepingStatusType,
     val startAt: LocalDate,
     val endAt: LocalDate,
 )

--- a/services/service-out-sleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/application/outsleeping/data/response/OutSleepingResponse.kt
+++ b/services/service-out-sleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/application/outsleeping/data/response/OutSleepingResponse.kt
@@ -1,6 +1,7 @@
 package com.b1nd.dodamdodam.outsleeping.application.outsleeping.data.response
 
 import com.b1nd.dodamdodam.outsleeping.domain.outsleeping.enumeration.OutSleepingStatus
+import com.b1nd.dodamdodam.outsleeping.domain.outsleeping.enumeration.OutSleepingStatusType
 import java.time.LocalDate
 import java.util.UUID
 
@@ -8,6 +9,7 @@ data class OutSleepingResponse(
     val publicId: UUID,
     val reason: String,
     val status: OutSleepingStatus,
+    val statusType: OutSleepingStatusType,
     val student: StudentResponse?,
     val startAt: LocalDate,
     val endAt: LocalDate,

--- a/services/service-out-sleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/domain/deadline/service/OutSleepingDeadlineService.kt
+++ b/services/service-out-sleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/domain/deadline/service/OutSleepingDeadlineService.kt
@@ -2,6 +2,7 @@ package com.b1nd.dodamdodam.outsleeping.domain.deadline.service
 
 import com.b1nd.dodamdodam.outsleeping.domain.deadline.entity.OutSleepingDeadlineEntity
 import com.b1nd.dodamdodam.outsleeping.domain.deadline.repository.OutSleepingDeadlineRepository
+import com.b1nd.dodamdodam.outsleeping.domain.outsleeping.enumeration.OutSleepingStatusType
 import com.b1nd.dodamdodam.outsleeping.domain.outsleeping.exception.OutSleepingDeadlineExceededException
 import org.springframework.stereotype.Service
 import java.time.DayOfWeek
@@ -32,13 +33,14 @@ class OutSleepingDeadlineService(
         )
     }
 
-    fun validateDeadline() {
-        val deadline = deadlineRepository.findAll().firstOrNull() ?: return
+    fun validateDeadline(): OutSleepingStatusType {
+        val deadline = deadlineRepository.findAll().firstOrNull() ?: return OutSleepingStatusType.NORMAL
 
         val now = LocalDateTime.now()
         if (!isWithinRange(now.dayOfWeek, now.toLocalTime(), deadline)) {
-            throw OutSleepingDeadlineExceededException()
+            return OutSleepingStatusType.LATE
         }
+        return OutSleepingStatusType.NORMAL
     }
 
     private fun isWithinRange(

--- a/services/service-out-sleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/domain/outsleeping/entity/OutSleepingEntity.kt
+++ b/services/service-out-sleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/domain/outsleeping/entity/OutSleepingEntity.kt
@@ -3,6 +3,7 @@ package com.b1nd.dodamdodam.outsleeping.domain.outsleeping.entity
 import com.b1nd.dodamdodam.core.common.uuid.UuidV7
 import com.b1nd.dodamdodam.core.jpa.entity.BaseTimeEntity
 import com.b1nd.dodamdodam.outsleeping.domain.outsleeping.enumeration.OutSleepingStatus
+import com.b1nd.dodamdodam.outsleeping.domain.outsleeping.enumeration.OutSleepingStatusType
 import com.b1nd.dodamdodam.outsleeping.domain.outsleeping.exception.OutSleepingAlreadyProcessedException
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
@@ -40,6 +41,9 @@ class OutSleepingEntity(
 
     @Column(name = "deny_reason")
     var denyReason: String? = null,
+
+    @Enumerated(EnumType.STRING)
+    var statusType: OutSleepingStatusType,
 ) : BaseTimeEntity() {
 
     @Id
@@ -74,11 +78,12 @@ class OutSleepingEntity(
         this.denyReason = null
     }
 
-    fun update(reason: String, startAt: LocalDate, endAt: LocalDate) {
+    fun update(reason: String, startAt: LocalDate, endAt: LocalDate, type: OutSleepingStatusType) {
         validatePending()
         this.reason = reason
         this.startAt = startAt
         this.endAt = endAt
+        this.statusType = type
     }
 
     private fun validatePending() {

--- a/services/service-out-sleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/domain/outsleeping/entity/OutSleepingEntity.kt
+++ b/services/service-out-sleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/domain/outsleeping/entity/OutSleepingEntity.kt
@@ -43,6 +43,7 @@ class OutSleepingEntity(
     var denyReason: String? = null,
 
     @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
     var statusType: OutSleepingStatusType,
 ) : BaseTimeEntity() {
 

--- a/services/service-out-sleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/domain/outsleeping/enumeration/OutSleepingStatusType.kt
+++ b/services/service-out-sleeping/src/main/kotlin/com/b1nd/dodamdodam/outsleeping/domain/outsleeping/enumeration/OutSleepingStatusType.kt
@@ -1,0 +1,6 @@
+package com.b1nd.dodamdodam.outsleeping.domain.outsleeping.enumeration
+
+enum class OutSleepingStatusType {
+    NORMAL,
+    LATE
+}

--- a/services/service-out-sleeping/src/main/resources/database/migration/V20260825__add_status_type_to_out_sleepings.sql
+++ b/services/service-out-sleeping/src/main/resources/database/migration/V20260825__add_status_type_to_out_sleepings.sql
@@ -1,0 +1,1 @@
+ALTER TABLE out_sleepings ADD COLUMN status_type VARCHAR(20) NOT NULL DEFAULT 'NORMAL';


### PR DESCRIPTION
## 변경 내용

<!-- 이 PR에서 무엇을 변경했는지 간단히 요약해주세요 -->

외박 신청 마감 시간이 지난 경우 **예외로 신청을 막던 동작을 제거하고, 정상(`NORMAL`) 신청과 지연(`LATE`) 신청을 구분해서 저장하도록** 변경했습니다. 선생님이 조회 시 지연 신청 여부를 바로 확인할 수 있습니다.

- `OutSleepingStatusType` enum 추가 (`NORMAL`, `LATE`)
- `OutSleepingDeadlineService.validateDeadline()` 이 예외를 던지지 않고 `OutSleepingStatusType` 을 반환하도록 변경
  - 마감 설정이 없으면 `NORMAL`, 마감 시간 범위를 벗어나면 `LATE`
- `OutSleepingEntity` 에 `statusType` 필드 추가, `update()` 시에도 재계산된 타입으로 갱신
- 신청(`apply`) / 수정(`modify`) 시 판정된 타입을 엔티티에 저장
- 조회 응답(`OutSleepingResponse`, `MyOutSleepingResponse`)에 `statusType` 필드 추가
  - 적용 엔드포인트: `GET /out-sleeping`, `GET /out-sleeping/valid`, `GET /out-sleeping/me`, OpenAPI `getValid`
- (부수 수정) `NightStudyUseCase.validateApplicationAvailability()` 에서 `LocalDateTime.now()` 가 서버 기본 타임존을 쓰고 있어 `Asia/Seoul` 기준으로 통일

## 관련 이슈

<!-- 관련된 이슈를 연결해주세요 -->
- Resolves #309

## 테스트 방법

<!-- 어떻게 테스트했는지 설명해주세요 -->
- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 완료
- [x] 수동 테스트 완료

확인 시나리오:
1. 마감 시간 **이내**에 외박 신청 → 저장 후 조회 시 `statusType: "NORMAL"`
2. 마감 시간 **이후**에 외박 신청 → 400 에러 없이 신청 성공, 조회 시 `statusType: "LATE"`
3. 정상 신청 건을 마감 이후에 수정(`PATCH /out-sleeping/{publicId}`) → `statusType` 이 `LATE` 로 갱신
4. `GET /out-sleeping/me`, `GET /out-sleeping?date=`, `GET /out-sleeping/valid` 응답에 `statusType` 필드 노출 확인

## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 완료했습니다
- [ ] 변경 사항에 대한 테스트를 추가했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [ ] Breaking Changes가 없습니다


## 기타 사항
<!-- 리뷰어가 특별히 주의해서 봐야 할 부분이나 추가 설명 -->