### PR TITLE
feat: 프로젝트실 층 데이터 추가

### DIFF
--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/NightStudyUseCase.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/NightStudyUseCase.kt
@@ -42,6 +42,10 @@ class NightStudyUseCase(
     private val outSleepingClient: OutSleepingClient
 ) {
 
+    companion object {
+        private const val DEFAULT_FLOOR = 2
+    }
+
     fun applyPersonalNightStudy(request: PersonalNightStudyApplyRequest): Response<Any> {
         val userId = PassportHolder.current().requireUserId()
         validateApplicationAvailability(request.startAt, request.period)
@@ -235,11 +239,11 @@ class NightStudyUseCase(
 
     private fun resolveFloor(nightStudy: NightStudyEntity, user: UserResponse?): Int =
         if (nightStudy.type == NightStudyType.PROJECT) {
-            if (nightStudy.room?.name == "LAB13") 3 else 2
+            nightStudy.room?.floor ?: DEFAULT_FLOOR
         } else {
             val grade = user?.student?.grade
             val classNo = user?.student?.room
-            if (grade == 2 || (grade == 1 && classNo == 4)) 3 else 2
+            if (grade == 2 || (grade == 1 && classNo == 4)) 3 else DEFAULT_FLOOR
         }
 
     fun unassignRoom(id: UUID): Response<Any> {

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/room/ProjectRoomUseCase.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/room/ProjectRoomUseCase.kt
@@ -77,7 +77,7 @@ class ProjectRoomUseCase(
     }
 
     fun update(id: Long, request: SaveProjectRoomRequest): Response<Any> {
-        projectRoomService.update(id, request.name)
+        projectRoomService.update(id, request.name, request.floor)
         return Response.ok("방 정보를 수정했어요.")
     }
 

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/room/data/ProjectRoomMapper.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/room/data/ProjectRoomMapper.kt
@@ -5,13 +5,14 @@ import com.b1nd.dodamdodam.nightstudy.application.room.data.response.ProjectRoom
 import com.b1nd.dodamdodam.nightstudy.domain.room.command.RoomPeriodCommand
 import com.b1nd.dodamdodam.nightstudy.domain.room.entity.ProjectRoomEntity
 
-fun SaveProjectRoomRequest.toEntity() = ProjectRoomEntity(name = name)
+fun SaveProjectRoomRequest.toEntity() = ProjectRoomEntity(name = name, floor = floor)
 
 fun ProjectRoomEntity.toResponse(inUsePeriods: Set<Pair<Long, Int>>): ProjectRoomResponse {
     val roomId = id!!
     return ProjectRoomResponse(
         id = roomId,
         name = name,
+        floor = floor,
         inUse = ProjectRoomResponse.InUse(
             period1 = (roomId to 1) in inUsePeriods,
             period2 = (roomId to 2) in inUsePeriods,

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/room/data/request/SaveProjectRoomRequest.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/room/data/request/SaveProjectRoomRequest.kt
@@ -1,8 +1,11 @@
 package com.b1nd.dodamdodam.nightstudy.application.room.data.request
 
 import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
 
 data class SaveProjectRoomRequest(
     @NotBlank
     val name: String,
+    @NotNull
+    val floor: Int
 )

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/room/data/response/ProjectRoomResponse.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/room/data/response/ProjectRoomResponse.kt
@@ -3,6 +3,7 @@ package com.b1nd.dodamdodam.nightstudy.application.room.data.response
 data class ProjectRoomResponse(
     val id: Long,
     val name: String,
+    val floor: Int,
     val inUse: InUse,
 ) {
     data class InUse(

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/room/entity/ProjectRoomEntity.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/room/entity/ProjectRoomEntity.kt
@@ -13,12 +13,16 @@ import jakarta.persistence.Table
 class ProjectRoomEntity(
     @Column(length = 100, nullable = false, unique = true)
     var name: String,
+
+    @Column(nullable = false)
+    var floor: Int,
 ) : BaseTimeEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long? = null
 
-    fun update(name: String) {
+    fun update(name: String, floor: Int) {
         this.name = name
+        this.floor = floor
     }
 }

--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/room/service/ProjectRoomService.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/domain/room/service/ProjectRoomService.kt
@@ -28,9 +28,9 @@ class ProjectRoomService(
     fun getById(id: Long): ProjectRoomEntity =
         projectRoomRepository.findById(id).orElseThrow { ProjectRoomNotFoundException() }
 
-    fun update(id: Long, name: String) {
+    fun update(id: Long, name: String, floor: Int) {
         checkNameExists(name)
-        getById(id).update(name)
+        getById(id).update(name, floor)
     }
 
     fun delete(id: Long) {

--- a/services/service-nightstudy/src/main/resources/database/migration/V20260825__add_floor_to_project_rooms.sql
+++ b/services/service-nightstudy/src/main/resources/database/migration/V20260825__add_floor_to_project_rooms.sql
@@ -1,0 +1,6 @@
+ALTER TABLE project_rooms
+    ADD COLUMN floor INT NOT NULL DEFAULT 2;
+
+UPDATE project_rooms
+SET floor = 3
+WHERE name = 'LAB13';


### PR DESCRIPTION
## 변경 내용
LAB13실을 3층으로 분류하던 하드코딩을 제거하고, project_rooms에 floor 컬럼을 추가해 층 정보를 데이터로 관리하도록 변경
<!-- 이 PR에서 무엇을 변경했는지 간단히 요약해주세요 -->


## 관련 이슈

<!-- 관련된 이슈를 연결해주세요 -->
- Resolves #312 


## 테스트 방법

<!-- 어떻게 테스트했는지 설명해주세요 -->
- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 완료
- [x] 수동 테스트 완료


## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 완료했습니다
- [ ] 변경 사항에 대한 테스트를 추가했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [x] Breaking Changes가 없습니다


## 기타 사항

<!-- 리뷰어가 특별히 주의해서 봐야 할 부분이나 추가 설명 -->