### PR TITLE
ci: develop CD 빌드 속도 개선

### DIFF
--- a/.github/scripts/develop/build-spring.sh
+++ b/.github/scripts/develop/build-spring.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${SERVICES_JSON:?SERVICES_JSON is required}"
+
+services=()
+while IFS= read -r service; do
+  services+=("${service}")
+done < <(jq -r '.[]' <<< "${SERVICES_JSON}")
+
+if [ "${#services[@]}" -eq 0 ]; then
+  echo "No Spring services to build."
+  exit 0
+fi
+
+tasks=()
+for service in "${services[@]}"; do
+  tasks+=(":services:service-${service}:build")
+done
+
+chmod +x gradlew
+./gradlew "${tasks[@]}" -x test --no-daemon
+
+artifact_dir=build/develop-spring-jars
+mkdir -p "${artifact_dir}"
+
+for service in "${services[@]}"; do
+  libs_dir="services/service-${service}/build/libs"
+  jar=$(find "${libs_dir}" -name "service-${service}*.jar" ! -name "*-plain.jar" -print -quit)
+  if [ -z "${jar}" ]; then
+    echo "No boot jar found for service-${service} in ${libs_dir}" >&2
+    exit 1
+  fi
+
+  cp "${jar}" "${artifact_dir}/service-${service}.jar"
+done
+
+echo "Prepared Spring artifacts for: ${services[*]}"

--- a/.github/scripts/develop/detect-changes.sh
+++ b/.github/scripts/develop/detect-changes.sh
@@ -38,13 +38,33 @@ if [ "${#services[@]}" -gt 0 ]; then
   has_services=true
 fi
 
+spring_services=()
+has_notification=false
+for service in "${services[@]}"; do
+  if [ "${service}" = notification ]; then
+    has_notification=true
+  else
+    spring_services+=("${service}")
+  fi
+done
+
+spring_services_json='[]'
+has_spring=false
+if [ "${#spring_services[@]}" -gt 0 ]; then
+  spring_services_json=$(printf '%s\n' "${spring_services[@]}" | jq -Rsc 'split("\n") | map(select(length > 0))')
+  has_spring=true
+fi
+
 should_deploy=$has_services
 if printf '%s\n' "$changed_files" | grep -Eq '^builds/develop/'; then
   should_deploy=true
 fi
 
 echo "services=$services_json" >> "$GITHUB_OUTPUT"
+echo "spring_services=$spring_services_json" >> "$GITHUB_OUTPUT"
 echo "has_services=$has_services" >> "$GITHUB_OUTPUT"
+echo "has_spring=$has_spring" >> "$GITHUB_OUTPUT"
+echo "has_notification=$has_notification" >> "$GITHUB_OUTPUT"
 echo "should_deploy=$should_deploy" >> "$GITHUB_OUTPUT"
 echo "Changed services: ${services[*]:-none}"
 echo "Deploy required: $should_deploy"

--- a/.github/workflows/cd-develop.yml
+++ b/.github/workflows/cd-develop.yml
@@ -69,7 +69,7 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts', 'gradle/libs.versions.toml') }}-${{ matrix.service }}
+          key: ${{ runner.os }}-gradle-develop-${{ hashFiles('**/*.gradle.kts', 'gradle/libs.versions.toml') }}
           restore-keys: ${{ runner.os }}-gradle-
 
       - name: Build Spring service

--- a/.github/workflows/cd-develop.yml
+++ b/.github/workflows/cd-develop.yml
@@ -16,7 +16,7 @@ permissions:
 
 concurrency:
   group: develop-deployment
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   detect:

--- a/.github/workflows/cd-develop.yml
+++ b/.github/workflows/cd-develop.yml
@@ -23,7 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       services: ${{ steps.changes.outputs.services }}
+      spring_services: ${{ steps.changes.outputs.spring_services }}
       has_services: ${{ steps.changes.outputs.has_services }}
+      has_spring: ${{ steps.changes.outputs.has_spring }}
+      has_notification: ${{ steps.changes.outputs.has_notification }}
       should_deploy: ${{ steps.changes.outputs.should_deploy }}
     steps:
       - name: Checkout full history
@@ -39,31 +42,21 @@ jobs:
           FORCE_ALL: ${{ github.event_name == 'workflow_dispatch' && inputs.build_all || false }}
         run: bash .github/scripts/develop/detect-changes.sh
 
-  build-and-publish:
+  build-spring:
     needs: detect
-    if: needs.detect.outputs.has_services == 'true'
-    environment: development
+    if: needs.detect.outputs.has_spring == 'true'
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      max-parallel: 2
-      matrix:
-        service: ${{ fromJSON(needs.detect.outputs.services) }}
-    env:
-      IMAGE_PREFIX: ${{ secrets.DOCKERHUB_USERNAME }}/dodam
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Set up JDK 21
-        if: matrix.service != 'notification'
         uses: actions/setup-java@v4
         with:
           java-version: '21'
           distribution: temurin
 
       - name: Cache Gradle
-        if: matrix.service != 'notification'
         uses: actions/cache@v4
         with:
           path: |
@@ -72,31 +65,54 @@ jobs:
           key: ${{ runner.os }}-gradle-develop-${{ hashFiles('**/*.gradle.kts', 'gradle/libs.versions.toml') }}
           restore-keys: ${{ runner.os }}-gradle-
 
-      - name: Build Spring service
-        if: matrix.service != 'notification'
+      - name: Build Spring services once
         env:
-          SERVICE: ${{ matrix.service }}
-        run: bash .github/scripts/production/build/spring.sh
+          SERVICES_JSON: ${{ needs.detect.outputs.spring_services }}
+        run: bash .github/scripts/develop/build-spring.sh
 
-      - name: Set up Node.js
-        if: matrix.service == 'notification'
-        uses: actions/setup-node@v4
+      - name: Upload Spring JARs
+        uses: actions/upload-artifact@v4
         with:
-          node-version: '20'
-          cache: npm
-          cache-dependency-path: services/service-notification/package-lock.json
+          name: develop-spring-jars-${{ github.sha }}
+          path: build/develop-spring-jars/
+          retention-days: 1
+          if-no-files-found: error
 
-      - name: Build notification service
-        if: matrix.service == 'notification'
-        run: bash .github/scripts/production/build/notification.sh
+  publish-spring:
+    needs: [detect, build-spring]
+    if: needs.detect.outputs.has_spring == 'true'
+    environment: development
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 5
+      matrix:
+        service: ${{ fromJSON(needs.detect.outputs.spring_services) }}
+    env:
+      IMAGE_PREFIX: ${{ secrets.DOCKERHUB_USERNAME }}/dodam
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Download Spring JARs
+        uses: actions/download-artifact@v4
+        with:
+          name: develop-spring-jars-${{ github.sha }}
+          path: build/develop-spring-jars
+
+      - name: Prepare Docker build context
+        run: |
+          mkdir -p "services/service-${{ matrix.service }}/build/libs"
+          cp "build/develop-spring-jars/service-${{ matrix.service }}.jar" \
+            "services/service-${{ matrix.service }}/build/libs/service-${{ matrix.service }}.jar"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
         with:
           platforms: linux/arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
@@ -106,13 +122,11 @@ jobs:
 
       - name: Resolve Spring Dockerfile
         id: dockerfile
-        if: matrix.service != 'notification'
         env:
           SERVICE: ${{ matrix.service }}
         run: bash .github/scripts/production/build/resolve-dockerfile.sh
 
       - name: Build and publish Spring image
-        if: matrix.service != 'notification'
         uses: docker/build-push-action@v6
         with:
           context: services/service-${{ matrix.service }}/build/libs
@@ -124,8 +138,42 @@ jobs:
             ${{ env.IMAGE_PREFIX }}-${{ matrix.service }}:dev-${{ github.sha }}
           build-args: JAR_FILE=service-${{ matrix.service }}.jar
 
+  publish-notification:
+    needs: detect
+    if: needs.detect.outputs.has_notification == 'true'
+    environment: development
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_PREFIX: ${{ secrets.DOCKERHUB_USERNAME }}/dodam
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: services/service-notification/package-lock.json
+
+      - name: Build notification service
+        run: bash .github/scripts/production/build/notification.sh
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Build and publish notification image
-        if: matrix.service == 'notification'
         uses: docker/build-push-action@v6
         with:
           context: services/service-notification
@@ -137,8 +185,13 @@ jobs:
             ${{ env.IMAGE_PREFIX }}-notification:dev-${{ github.sha }}
 
   deploy:
-    needs: [detect, build-and-publish]
-    if: always() && needs.detect.outputs.should_deploy == 'true' && (needs.build-and-publish.result == 'success' || needs.build-and-publish.result == 'skipped')
+    needs: [detect, build-spring, publish-spring, publish-notification]
+    if: >-
+      always() &&
+      needs.detect.outputs.should_deploy == 'true' &&
+      (needs.build-spring.result == 'success' || needs.build-spring.result == 'skipped') &&
+      (needs.publish-spring.result == 'success' || needs.publish-spring.result == 'skipped') &&
+      (needs.publish-notification.result == 'success' || needs.publish-notification.result == 'skipped')
     environment: development
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## 변경 내용

- Spring 서비스를 한 번의 Gradle 실행으로 빌드
- 생성된 JAR을 Artifact로 공유
- Docker 이미지 게시를 최대 5개까지 병렬 처리
- Notification 빌드를 별도 작업으로 분리
- 이전 develop 배포가 진행 중이면 자동 취소

## 관련 이슈

- Resolves #315
- See also #288
- See also #314

## 테스트 방법

- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 완료
- [x] 수동 테스트 완료

### 검증 내용

- Shell 스크립트 문법 검사
- GitHub Actions YAML 파싱
- Gateway와 Auth를 단일 Gradle 프로세스로 빌드
- 서비스별 JAR Artifact 생성 확인

## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 완료했습니다
- [ ] 변경 사항에 대한 테스트를 추가했습니다
- [x] 문서 업데이트가 필요하지 않습니다
- [x] Breaking Changes가 없습니다

## 기타 사항

develop CD만 개선하며 main 및 production 배포 파이프라인은 변경하지 않습니다.