### PR TITLE
fix: 업로드 파일 형식 검증 우회 차단

### DIFF
--- a/services/service-file/src/main/kotlin/com/b1nd/dodamdodam/file/application/file/FileUseCase.kt
+++ b/services/service-file/src/main/kotlin/com/b1nd/dodamdodam/file/application/file/FileUseCase.kt
@@ -14,8 +14,8 @@ class FileUseCase(
     private val s3FileStorageClient: S3FileStorageClient,
 ) {
     fun upload(file: MultipartFile, allowType: FileType?, width: Int?, height: Int?): Response<FileUploadResponse> {
-        fileValidationService.validate(file, allowType, width, height)
-        val url = s3FileStorageClient.upload(file)
+        val metadata = fileValidationService.validate(file, allowType, width, height)
+        val url = s3FileStorageClient.upload(file, metadata)
 
         return Response.created(
             "파일이 업로드되었어요.",

--- a/services/service-file/src/main/kotlin/com/b1nd/dodamdodam/file/domain/enumeration/FileType.kt
+++ b/services/service-file/src/main/kotlin/com/b1nd/dodamdodam/file/domain/enumeration/FileType.kt
@@ -6,7 +6,7 @@ enum class FileType(
     val supportsDimensionCheck: Boolean,
 ) {
     IMAGE(
-        extensions = setOf("jpg", "jpeg", "png", "bmp", "webp", "svg", "tiff"),
+        extensions = setOf("jpg", "jpeg", "png", "bmp", "webp", "tiff"),
         mimePrefix = "image/",
         supportsDimensionCheck = true,
     ),
@@ -32,9 +32,45 @@ enum class FileType(
     );
 
     companion object {
+        private val contentTypes = mapOf(
+            "jpg" to "image/jpeg",
+            "jpeg" to "image/jpeg",
+            "png" to "image/png",
+            "bmp" to "image/bmp",
+            "webp" to "image/webp",
+            "tiff" to "image/tiff",
+            "gif" to "image/gif",
+            "mp4" to "video/mp4",
+            "avi" to "video/x-msvideo",
+            "mov" to "video/quicktime",
+            "mkv" to "video/x-matroska",
+            "webm" to "video/webm",
+            "wmv" to "video/x-ms-wmv",
+            "flv" to "video/x-flv",
+            "mp3" to "audio/mpeg",
+            "wav" to "audio/wav",
+            "ogg" to "audio/ogg",
+            "flac" to "audio/flac",
+            "aac" to "audio/aac",
+            "wma" to "audio/x-ms-wma",
+            "pdf" to "application/pdf",
+            "doc" to "application/msword",
+            "docx" to "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            "xls" to "application/vnd.ms-excel",
+            "xlsx" to "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            "ppt" to "application/vnd.ms-powerpoint",
+            "pptx" to "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+            "txt" to "text/plain",
+            "csv" to "text/csv",
+            "hwp" to "application/x-hwp",
+        )
+
         fun fromExtension(extension: String): FileType? {
             val ext = extension.lowercase()
             return entries.firstOrNull { ext in it.extensions }
         }
+
+        fun contentTypeFromExtension(extension: String): String? =
+            contentTypes[extension.lowercase()]
     }
 }

--- a/services/service-file/src/main/kotlin/com/b1nd/dodamdodam/file/domain/service/FileValidationService.kt
+++ b/services/service-file/src/main/kotlin/com/b1nd/dodamdodam/file/domain/service/FileValidationService.kt
@@ -9,31 +9,42 @@ import org.springframework.stereotype.Service
 import org.springframework.web.multipart.MultipartFile
 import javax.imageio.ImageIO
 
+data class ValidatedFileMetadata(
+    val extension: String,
+    val contentType: String,
+)
+
 @Service
 class FileValidationService {
 
-    fun validate(file: MultipartFile, allowType: FileType?, width: Int?, height: Int?) {
+    fun validate(file: MultipartFile, allowType: FileType?, width: Int?, height: Int?): ValidatedFileMetadata {
         if (file.isEmpty) throw FileEmptyException()
 
-        val detectedType = file.detectType()
+        val extension = file.extractExtension()
+        val detectedType = FileType.fromExtension(extension)
+            ?: throw FileTypeNotAllowedException()
 
         if (allowType != null && detectedType != allowType) {
             throw FileTypeNotAllowedException()
         }
 
-        if (width != null && height != null && detectedType?.supportsDimensionCheck == true) {
+        if (width != null && height != null && detectedType.supportsDimensionCheck) {
             validateDimension(file, width, height)
         }
+
+        return ValidatedFileMetadata(
+            extension = extension,
+            contentType = FileType.contentTypeFromExtension(extension)
+                ?: throw FileTypeNotAllowedException(),
+        )
     }
 
-    private fun MultipartFile.detectType(): FileType? {
-        val extension = originalFilename
+    private fun MultipartFile.extractExtension(): String =
+        originalFilename
             ?.substringAfterLast('.', "")
             ?.lowercase()
             ?.takeIf { it.isNotBlank() }
             ?: throw FileTypeNotAllowedException()
-        return FileType.fromExtension(extension)
-    }
 
     private fun validateDimension(file: MultipartFile, requiredWidth: Int, requiredHeight: Int) {
         val iis = ImageIO.createImageInputStream(file.inputStream)

--- a/services/service-file/src/main/kotlin/com/b1nd/dodamdodam/file/infrastructure/s3/S3FileStorageClient.kt
+++ b/services/service-file/src/main/kotlin/com/b1nd/dodamdodam/file/infrastructure/s3/S3FileStorageClient.kt
@@ -1,14 +1,13 @@
 package com.b1nd.dodamdodam.file.infrastructure.s3
 
 import com.b1nd.dodamdodam.file.domain.exception.FileUploadFailedException
+import com.b1nd.dodamdodam.file.domain.service.ValidatedFileMetadata
 import org.springframework.stereotype.Component
 import org.springframework.web.multipart.MultipartFile
 import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.ObjectCannedACL
 import software.amazon.awssdk.services.s3.model.PutObjectRequest
-import java.nio.file.Files
-import java.nio.file.Path
 import java.util.UUID
 
 @Component
@@ -16,15 +15,13 @@ class S3FileStorageClient(
     private val s3Client: S3Client,
     private val properties: S3Properties,
 ) {
-    fun upload(file: MultipartFile): String {
-        val extension = file.extractExtension()
-        val key = generateKey(extension)
-        val contentType = file.resolveContentType()
+    fun upload(file: MultipartFile, metadata: ValidatedFileMetadata): String {
+        val key = generateKey(metadata.extension)
 
         val request = PutObjectRequest.builder()
             .bucket(properties.bucket)
             .key(key)
-            .contentType(contentType)
+            .contentType(metadata.contentType)
             .contentLength(file.size)
             .apply {
                 if (properties.publicRead) {
@@ -42,12 +39,6 @@ class S3FileStorageClient(
         return buildFileUrl(key)
     }
 
-    private fun MultipartFile.extractExtension(): String =
-        originalFilename
-            ?.substringAfterLast('.', "")
-            ?.lowercase()
-            ?: ""
-
     private fun generateKey(extension: String): String {
         val uuid = UUID.randomUUID().toString()
         val filename = if (extension.isNotBlank()) "$uuid.$extension" else uuid
@@ -55,23 +46,10 @@ class S3FileStorageClient(
         return if (prefix.isNotBlank()) "$prefix/$filename" else filename
     }
 
-    private fun MultipartFile.resolveContentType(): String =
-        contentType
-            ?.takeIf { it.isNotBlank() && it != DEFAULT_CONTENT_TYPE }
-            ?: originalFilename
-                ?.let { Path.of(it).fileName }
-                ?.let { Files.probeContentType(it) }
-                ?.takeIf { it.isNotBlank() }
-            ?: DEFAULT_CONTENT_TYPE
-
     private fun buildFileUrl(key: String): String =
         if (properties.endpoint.isNotBlank()) {
             "${properties.endpoint.trimEnd('/')}/${properties.bucket}/$key"
         } else {
             "https://${properties.bucket}.s3.${properties.region}.amazonaws.com/$key"
         }
-
-    companion object {
-        private const val DEFAULT_CONTENT_TYPE = "application/octet-stream"
-    }
 }

--- a/services/service-file/src/test/kotlin/com/b1nd/dodamdodam/file/domain/service/FileValidationServiceTest.kt
+++ b/services/service-file/src/test/kotlin/com/b1nd/dodamdodam/file/domain/service/FileValidationServiceTest.kt
@@ -1,0 +1,80 @@
+package com.b1nd.dodamdodam.file.domain.service
+
+import com.b1nd.dodamdodam.file.domain.enumeration.FileType
+import com.b1nd.dodamdodam.file.domain.exception.FileTypeNotAllowedException
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.mock.web.MockMultipartFile
+
+class FileValidationServiceTest {
+
+    private val fileValidationService = FileValidationService()
+
+    @Test
+    fun `허용 목록에 없는 확장자는 allowType이 없어도 거부한다`() {
+        val file = MockMultipartFile(
+            "file",
+            "page.html",
+            "text/html",
+            "<html></html>".toByteArray(),
+        )
+
+        assertThrows<FileTypeNotAllowedException> {
+            fileValidationService.validate(file, null, null, null)
+        }
+    }
+
+    @Test
+    fun `브라우저에서 실행 가능한 SVG 파일은 거부한다`() {
+        val file = MockMultipartFile(
+            "file",
+            "image.svg",
+            "image/svg+xml",
+            "<svg onload=\"alert(1)\"></svg>".toByteArray(),
+        )
+
+        assertThrows<FileTypeNotAllowedException> {
+            fileValidationService.validate(file, null, null, null)
+        }
+    }
+
+    @Test
+    fun `클라이언트 Content-Type 대신 확장자의 안전한 Content-Type을 사용한다`() {
+        val file = MockMultipartFile(
+            "file",
+            "image.png",
+            "text/html",
+            "<html></html>".toByteArray(),
+        )
+
+        val metadata = fileValidationService.validate(file, FileType.IMAGE, null, null)
+
+        assertEquals("png", metadata.extension)
+        assertEquals("image/png", metadata.contentType)
+    }
+
+    @Test
+    fun `요청한 파일 타입과 확장자 타입이 다르면 거부한다`() {
+        val file = MockMultipartFile(
+            "file",
+            "video.mov",
+            "video/quicktime",
+            byteArrayOf(1),
+        )
+
+        assertThrows<FileTypeNotAllowedException> {
+            fileValidationService.validate(file, FileType.IMAGE, null, null)
+        }
+    }
+
+    @Test
+    fun `허용된 모든 확장자는 서버 Content-Type이 정의되어 있다`() {
+        FileType.entries
+            .flatMap { it.extensions }
+            .forEach { extension ->
+                assertNotNull(FileType.contentTypeFromExtension(extension))
+            }
+    }
+}


### PR DESCRIPTION
## 변경 내용

- 허용 목록에 없는 확장자는 `allowType` 생략 여부와 관계없이 거부
- 브라우저에서 실행 가능한 SVG 업로드 차단
- 클라이언트의 Content-Type 대신 서버에서 정의한 MIME 타입 사용
- 파일 검증 회귀 테스트 추가

## 관련 이슈

- Resolves #322

## 테스트 방법

- [x] 단위 테스트 추가/수정
- [ ] 통합 테스트 완료
- [ ] 수동 테스트 완료

테스트 명령: `./gradlew :services:service-file:test --no-daemon`

## 스크린샷 (UI 변경 시)

해당 없음

## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 완료했습니다
- [x] 변경 사항에 대한 테스트를 추가했습니다
- [x] 문서 업데이트가 필요하지 않습니다
- [ ] Breaking Changes가 없습니다

## 기타 사항

보안상 브라우저에서 실행될 수 있는 SVG 업로드도 차단했습니다 기존 aid 입력이 PNG/JPEG/WebP 로 제한될 수 있습니다