### PR TITLE
Develop

### DIFF
--- a/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/data/response/NightStudyTotalCountResponse.kt
+++ b/services/service-nightstudy/src/main/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/data/response/NightStudyTotalCountResponse.kt
@@ -3,34 +3,29 @@ package com.b1nd.dodamdodam.nightstudy.application.nightstudy.data.response
 import com.b1nd.dodamdodam.nightstudy.domain.nightstudy.enumeration.NightStudyType
 
 data class NightStudyTotalCountResponse(
-    val floors: List<FloorCount>,
-    val grades: List<GradeCount>,
-    val genders: List<GenderCount>,
-    val total: PeriodCount,
+    val personal: PeriodCount,
+    val project: PeriodCount,
 ) {
-    data class FloorCount(
-        val floor: Int,
-        val count: PeriodCount,
+    data class PeriodCount(
+        val period1: CategoryCount,
+        val period2: CategoryCount,
+    )
+
+    data class CategoryCount(
+        val grades: List<GradeCount>,
+        val floors: List<FloorCount>,
     )
 
     data class GradeCount(
         val grade: Int,
-        val count: PeriodCount,
+        val male: Int,
+        val female: Int,
     )
 
-    data class GenderCount(
-        val gender: String,
-        val count: PeriodCount,
-    )
-
-    data class PeriodCount(
-        val period1: TypeCount,
-        val period2: TypeCount,
-    )
-
-    data class TypeCount(
-        val personal: Int,
-        val project: Int,
+    data class FloorCount(
+        val floor: Int,
+        val male: Int,
+        val female: Int,
     )
 
     data class MemberCount(
@@ -43,41 +38,36 @@ data class NightStudyTotalCountResponse(
 
     companion object {
         fun of(members: List<MemberCount>): NightStudyTotalCountResponse {
-            fun typeCount(filtered: List<MemberCount>, period: Int) = TypeCount(
-                personal = filtered.count { it.period == period && it.type == NightStudyType.PERSONAL },
-                project = filtered.count { it.period == period && it.type == NightStudyType.PROJECT },
+            fun categoryCount(type: NightStudyType, period: Int): CategoryCount {
+                val filtered = members.filter { it.type == type && it.period == period }
+                val grades = (1..3).map { grade ->
+                    val gradeMembers = filtered.filter { it.grade == grade }
+                    GradeCount(
+                        grade = grade,
+                        male = gradeMembers.count { it.gender == "MALE" },
+                        female = gradeMembers.count { it.gender == "FEMALE" },
+                    )
+                }
+                val floors = listOf(2, 3).map { floor ->
+                    val floorMembers = filtered.filter { it.floor == floor }
+                    FloorCount(
+                        floor = floor,
+                        male = floorMembers.count { it.gender == "MALE" },
+                        female = floorMembers.count { it.gender == "FEMALE" },
+                    )
+                }
+
+                return CategoryCount(grades = grades, floors = floors)
+            }
+
+            fun periodCount(type: NightStudyType) = PeriodCount(
+                period1 = categoryCount(type, 1),
+                period2 = categoryCount(type, 2),
             )
-
-            fun periodCount(filtered: List<MemberCount>) = PeriodCount(
-                period1 = typeCount(filtered, 1),
-                period2 = typeCount(filtered, 2),
-            )
-
-            val floors = listOf(2, 3).map { floor ->
-                FloorCount(
-                    floor = floor,
-                    count = periodCount(members.filter { it.floor == floor }),
-                )
-            }
-            val grades = (1..3).map { grade ->
-                GradeCount(
-                    grade = grade,
-                    count = periodCount(members.filter { it.grade == grade }),
-                )
-            }
-
-            val genders = listOf("MALE", "FEMALE").map { gender ->
-                GenderCount(
-                    gender = gender,
-                    count = periodCount(members.filter { it.gender == gender }),
-                )
-            }
 
             return NightStudyTotalCountResponse(
-                floors = floors,
-                grades = grades,
-                genders = genders,
-                total = periodCount(members),
+                personal = periodCount(NightStudyType.PERSONAL),
+                project = periodCount(NightStudyType.PROJECT),
             )
         }
     }

--- a/services/service-nightstudy/src/test/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/NightStudyUseCaseCountTest.kt
+++ b/services/service-nightstudy/src/test/kotlin/com/b1nd/dodamdodam/nightstudy/application/nightstudy/NightStudyUseCaseCountTest.kt
@@ -56,14 +56,12 @@ class NightStudyUseCaseCountTest {
 
         val result = useCase.countTotalMembers().data!!
 
-        assertEquals(1, result.total.period1.project)
-        assertEquals(0, result.total.period1.personal)
-        assertEquals(0, result.total.period2.project)
-        assertEquals(1, result.total.period2.personal)
-        assertEquals(1, result.floors.single { it.floor == 3 }.count.period1.project)
-        assertEquals(1, result.floors.single { it.floor == 2 }.count.period2.personal)
-        assertEquals(1, result.grades.single { it.grade == 1 }.count.period1.project)
-        assertEquals(1, result.grades.single { it.grade == 1 }.count.period2.personal)
+        assertEquals(1, result.project.period1.grades.single { it.grade == 1 }.male)
+        assertEquals(1, result.project.period1.floors.single { it.floor == 3 }.male)
+        assertEquals(0, result.personal.period1.grades.single { it.grade == 1 }.male)
+        assertEquals(0, result.project.period2.grades.single { it.grade == 1 }.male)
+        assertEquals(1, result.personal.period2.grades.single { it.grade == 1 }.male)
+        assertEquals(1, result.personal.period2.floors.single { it.floor == 2 }.male)
     }
 
     @Test
@@ -84,9 +82,8 @@ class NightStudyUseCaseCountTest {
 
         val result = useCase.countTotalMembers().data!!
 
-        assertEquals(1, result.total.period1.personal)
-        assertEquals(1, result.total.period2.personal)
-        assertEquals(1, result.grades.single { it.grade == 1 }.count.period1.personal)
+        assertEquals(1, result.personal.period1.grades.single { it.grade == 1 }.male)
+        assertEquals(1, result.personal.period2.grades.single { it.grade == 1 }.male)
     }
 
     @Test
@@ -105,7 +102,7 @@ class NightStudyUseCaseCountTest {
 
         val result = useCase.countTotalMembers().data!!
 
-        assertEquals(1, result.total.period1.personal)
+        assertEquals(1, result.personal.period1.grades.single { it.grade == 1 }.male)
     }
 
     @Test
@@ -122,11 +119,11 @@ class NightStudyUseCaseCountTest {
 
         val result = useCase.countTotalMembers().data!!
 
-        assertEquals(1, result.total.period1.personal)
+        assertEquals(1, result.personal.period1.grades.single { it.grade == 1 }.male)
     }
 
     @Test
-    fun `성별별로 인원수를 집계한다`() {
+    fun `학년과 층별로 성별 인원수를 집계한다`() {
         val maleUserId = UUID.randomUUID()
         val femaleUserId = UUID.randomUUID()
         val personal = nightStudy(id = 1L, type = NightStudyType.PERSONAL, period = 1)
@@ -143,10 +140,15 @@ class NightStudyUseCaseCountTest {
 
         val result = useCase.countTotalMembers().data!!
 
-        assertEquals(1, result.genders.single { it.gender == "MALE" }.count.period1.personal)
-        assertEquals(1, result.genders.single { it.gender == "FEMALE" }.count.period1.personal)
-        assertEquals(0, result.genders.single { it.gender == "MALE" }.count.period2.personal)
-        assertEquals(2, result.total.period1.personal)
+        assertEquals(1, result.personal.period1.grades.single { it.grade == 1 }.male)
+        assertEquals(0, result.personal.period1.grades.single { it.grade == 1 }.female)
+        assertEquals(0, result.personal.period1.grades.single { it.grade == 2 }.male)
+        assertEquals(1, result.personal.period1.grades.single { it.grade == 2 }.female)
+        assertEquals(1, result.personal.period1.floors.single { it.floor == 2 }.male)
+        assertEquals(1, result.personal.period1.floors.single { it.floor == 3 }.female)
+        assertEquals(0, result.personal.period1.grades.single { it.grade == 3 }.male)
+        assertEquals(0, result.personal.period2.floors.single { it.floor == 3 }.female)
+        assertEquals(0, result.personal.period2.grades.single { it.grade == 1 }.male)
     }
 
     private fun nightStudy(


### PR DESCRIPTION
## 변경 내용

- 심자 인원 조회 응답 구조를 심자 유형 → 차수 → 학년/층 → 성별 순으로 변경했습니다.
- 개인 심자와 프로젝트 심자를 `personal`, `project` 필드로 구분했습니다.
- 각 심자 유형을 1차와 2차(`period1`, `period2`)로 구분했습니다.
- 학년별 및 층별 남학생·여학생 인원수를 각각 `male`, `female` 필드로 제공합니다.
- 변경된 응답 구조에 맞게 `NightStudyUseCaseCountTest`의 검증 항목을 수정했습니다.

## 관련 이슈

- Resolves #328

## 테스트 방법

- [x] 단위 테스트 추가/수정
- [ ] 통합 테스트 완료
- [ ] 수동 테스트 완료

## 스크린샷 (UI 변경 시)

해당 없음

## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 완료했습니다
- [x] 변경 사항에 대한 테스트를 추가했습니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [ ] Breaking Changes가 없습니다

## 기타 사항

기존 심자 인원 조회 API의 응답 구조가 변경되므로, 해당 API를 사용하는 클라이언트에서 응답 모델 수정이 필요합니다.