### PR TITLE
fix: 컴시간 주차별 시간표 동기화 수정 (#332)

### DIFF
--- a/services/service-neis/src/main/kotlin/com/b1nd/dodamdodam/neis/infrastructure/comcigan/ComciganClient.kt
+++ b/services/service-neis/src/main/kotlin/com/b1nd/dodamdodam/neis/infrastructure/comcigan/ComciganClient.kt
@@ -78,8 +78,8 @@ class ComciganClient(
 
     fun fetchWeeklyTimeTables(mondayDate: LocalDate): List<ParsedTimeTable> {
         val base = fetchTimetable()
-        val r = resoloveWeek(base, mondayDate)
-        val json = if (r==0) base else fetchTimetable(r)
+        val week = resolveWeek(base, mondayDate)
+        val json = if (week == DEFAULT_WEEK) base else fetchTimetable(week)
         val subjects = json["자료$sbNum"]
         val teachers = json["자료$thNum"]
         val timetableData = json["자료$dayNum"]
@@ -113,8 +113,8 @@ class ComciganClient(
 
         val dayIdx = dayOfWeek.value
         val base = fetchTimetable()
-        val r = resoloveWeek(base, date)
-        val json = if (r == 0) base else fetchTimetable(r)
+        val week = resolveWeek(base, date)
+        val json = if (week == DEFAULT_WEEK) base else fetchTimetable(week)
         val subjects = json["자료$sbNum"]
         val teachers = json["자료$thNum"]
         val timetableData = json["자료$dayNum"]
@@ -167,8 +167,8 @@ class ComciganClient(
         }
     }
 
-    private fun fetchTimetable(r: Int = 0): JsonNode {
-        val param = "$prefix${schoolCode}_${r}_1"
+    private fun fetchTimetable(week: Int = DEFAULT_WEEK): JsonNode {
+        val param = buildTimetableParameter(prefix, schoolCode, week)
         val encoded = Base64.getEncoder().encodeToString(param.toByteArray(Charsets.UTF_8))
         val body = fetchAsUtf8("$baseUrl?$encoded")
         return objectMapper.readTree(body.replace("\u0000", ""))
@@ -196,15 +196,23 @@ class ComciganClient(
         return node[index].asText("")
     }
 
-    private fun resoloveWeek(json: JsonNode, mondayDate: LocalDate): Int {
-        val weeks = json["일자자료"]
-        for (w in weeks) {
-            val label = w[1].asText()
-            val start = LocalDate.parse("20" + label.substringBefore(" ~ ").trim(), DateTimeFormatter.ofPattern("yyyy-MM-dd"))
-            val end = LocalDate.parse("20" + label.substringAfter("~ ").trim(), DateTimeFormatter.ofPattern("yyyy-MM-dd"))
-
-            if (!mondayDate.isBefore(start) && !mondayDate.isAfter(end)) return w[0].asInt() -1
-        }
-        return json["오늘r"].asInt()
+    companion object {
+        private const val DEFAULT_WEEK = 1
     }
+}
+
+internal fun buildTimetableParameter(prefix: String, schoolCode: Int, week: Int): String =
+    "${prefix}${schoolCode}_0_$week"
+
+internal fun resolveWeek(json: JsonNode, date: LocalDate): Int {
+    val dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+    val weeks = json["일자자료"]
+    for (week in weeks) {
+        val label = week[1].asText()
+        val start = LocalDate.parse("20" + label.substringBefore(" ~ ").trim(), dateFormatter)
+        val end = LocalDate.parse("20" + label.substringAfter("~ ").trim(), dateFormatter)
+
+        if (!date.isBefore(start) && !date.isAfter(end)) return week[0].asInt()
+    }
+    return json["오늘r"].asInt()
 }

--- a/services/service-neis/src/test/kotlin/com/b1nd/dodamdodam/neis/infrastructure/comcigan/ComciganClientTest.kt
+++ b/services/service-neis/src/test/kotlin/com/b1nd/dodamdodam/neis/infrastructure/comcigan/ComciganClientTest.kt
@@ -1,0 +1,35 @@
+package com.b1nd.dodamdodam.neis.infrastructure.comcigan
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class ComciganClientTest {
+    private val objectMapper = ObjectMapper()
+
+    @Test
+    fun `컴시간 요청 파라미터는 수정일 다음에 주차를 배치한다`() {
+        val parameter = buildTimetableParameter(prefix = "73629_", schoolCode = 20999, week = 2)
+
+        assertEquals("73629_20999_0_2", parameter)
+    }
+
+    @Test
+    fun `날짜에 해당하는 컴시간의 1부터 시작하는 주차 값을 반환한다`() {
+        val response = objectMapper.readTree(
+            """
+            {
+              "오늘r": 1,
+              "일자자료": [
+                [1, "26-09-07 ~ 26-09-12"],
+                [2, "26-09-14 ~ 26-09-19"]
+              ]
+            }
+            """.trimIndent()
+        )
+
+        assertEquals(1, resolveWeek(response, LocalDate.of(2026, 9, 10)))
+        assertEquals(2, resolveWeek(response, LocalDate.of(2026, 9, 14)))
+    }
+}


### PR DESCRIPTION
## 변경 내용

- 컴시간 API 요청 파라미터를 `학교코드_수정일_주차` 순서로 수정했습니다.
- 컴시간 응답의 1부터 시작하는 주차 값을 그대로 사용하도록 보정했습니다.
- 요청 파라미터와 주차 계산에 대한 회귀 테스트를 추가했습니다.

## 관련 이슈

- Resolves #332

## 테스트 방법

- [x] 단위 테스트 추가/수정
- [x] `./gradlew :services:service-neis:test --no-daemon`
- [x] 실제 컴시간 API에서 현재 주와 다음 주 응답 비교

## 스크린샷 (UI 변경 시)

해당 없음

## 체크리스트

- [x] 코드가 프로젝트의 코딩 스타일을 따릅니다
- [x] 자체 코드 리뷰를 완료했습니다
- [x] 변경 사항에 대한 테스트를 추가했습니다
- [x] 문서 업데이트가 필요하지 않습니다
- [x] Breaking Changes가 없습니다

## 기타 사항

기존에 잘못 저장된 시간표는 배포 후 현재 주와 다음 주를 다시 동기화해야 합니다.
